### PR TITLE
:herb: upgrade the go generator to `0.2.0`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,6 +2,6 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.1.0
+        version: 0.2.0
         github:
           repository: hookdeck/hookdeck-go-sdk


### PR DESCRIPTION
This version of the generator will generate string based Go enums and provide a factory method to initialize with a string as well.