### PR TITLE
:herb: Upgrade Go Generator to `0.3.0`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,6 +2,6 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.2.0
+        version: 0.3.0
         github:
           repository: hookdeck/hookdeck-go-sdk


### PR DESCRIPTION
This version of the Go Generator contains bugfixes/features: 
- Optional request properties will by typed as `Optional[T]` so that you can send explicit null values. 
- Errors that are unparsable will still return the underlying errror messages. 
- The client will expose nested clients as properties `hookdeck.Sources.UpdateSource()` instead of `hookdeck.Sources()`