### PR TITLE
:herb: Update `FilterRule` to contain arbitrary JSON

### DIFF
--- a/fern/api/openapi/openapi.yml
+++ b/fern/api/openapi/openapi.yml
@@ -2975,7 +2975,7 @@ components:
         - type: boolean
         - type: object
           properties: {}
-          additionalProperties: true
+          additionalProperties: false
       nullable: true
       description: JSON using our filter syntax to filter on request headers
       x-docs-type: JSON


### PR DESCRIPTION
When you remove the `schema` key, this signals that arbitrary JSON is acceptable. Read more [here](https://stackoverflow.com/questions/32841298/openapi-what-schema-to-accept-any-complex-json-value).