### PR TITLE
Upgrade fern-go-sdk to 0.4.1

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -2,6 +2,8 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.3.0
+        version: 0.4.1
+        config:
+          enableExplicitNull: true
         github:
           repository: hookdeck/hookdeck-go-sdk


### PR DESCRIPTION
This upgrades the `fern-go-sdk` generator so that it includes Fern's container types in the `Optional[T]` type, and a variety of other API changes (re: [release notes](https://github.com/fern-api/fern-go/releases/tag/0.4.0)).