### PR TITLE
Upgrade fern-go-sdk to 0.6.1

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -2,7 +2,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.4.1
+        version: 0.6.1
         config:
           enableExplicitNull: true
           module:
@@ -13,7 +13,7 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.4.1
+        version: 0.6.1
         config:
           enableExplicitNull: true
         github:


### PR DESCRIPTION
This upgrades the `fern-go-sdk` generator to `0.6.1` so that it resolves an issue related to sending empty request bodies. For details, see https://github.com/fern-api/fern-go/pull/73.