### PR TITLE
🌿 (chore): downgrade go generator and upgrade fern cli

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "hookdeck",
-  "version": "0.16.36"
+  "version": "0.16.37"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -2,7 +2,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.9.4
+        version: 0.6.1
         config:
           enableExplicitNull: true
           module:
@@ -13,7 +13,7 @@ groups:
   publish:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.9.4
+        version: 0.6.1
         config:
           enableExplicitNull: true
         github:

--- a/fern/openapi/openapi.json
+++ b/fern/openapi/openapi.json
@@ -1,9784 +1,17499 @@
 {
-  "paths": {
-    "/collections/{collection_name}/shards": {
-      "put": {
-        "tags": ["collections", "cluster"],
-        "summary": "Create shard key",
-        "operationId": "create_shard_key",
-        "requestBody": {
-          "description": "Shard key configuration",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateShardingKey"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to create shards for",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/shards/delete": {
-      "post": {
-        "tags": ["collections", "cluster"],
-        "summary": "Delete shard key",
-        "operationId": "delete_shard_key",
-        "requestBody": {
-          "description": "Select shard key to delete",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DropShardingKey"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to create shards for",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/telemetry": {
-      "get": {
-        "summary": "Collect telemetry data",
-        "description": "Collect telemetry data including app info, system info, collections info, cluster info, configs and statistics",
-        "operationId": "telemetry",
-        "tags": ["service"],
-        "parameters": [
-          {
-            "name": "anonymize",
-            "in": "query",
-            "description": "If true, anonymize result",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/TelemetryData"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/metrics": {
-      "get": {
-        "summary": "Collect Prometheus metrics data",
-        "description": "Collect metrics data including app info, collections info, cluster info and statistics",
-        "operationId": "metrics",
-        "tags": ["service"],
-        "parameters": [
-          {
-            "name": "anonymize",
-            "in": "query",
-            "description": "If true, anonymize result",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Metrics data in Prometheus format",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string",
-                  "example": "# HELP app_info information about qdrant server\n# TYPE app_info counter\napp_info{name=\"qdrant\",version=\"0.11.1\"} 1\n# HELP cluster_enabled is cluster support enabled\n# TYPE cluster_enabled gauge\ncluster_enabled 0\n# HELP collections_total number of collections\n# TYPE collections_total gauge\ncollections_total 1\n"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error"
-          }
-        }
-      }
-    },
-    "/locks": {
-      "post": {
-        "summary": "Set lock options",
-        "description": "Set lock options. If write is locked, all write operations and collection creation are forbidden. Returns previous lock options",
-        "operationId": "post_locks",
-        "tags": ["service"],
-        "requestBody": {
-          "description": "Lock options and optional error message",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LocksOption"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/LocksOption"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "summary": "Get lock options",
-        "description": "Get lock options. If write is locked, all write operations and collection creation are forbidden",
-        "operationId": "get_locks",
-        "tags": ["service"],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/LocksOption"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/healthz": {
-      "get": {
-        "summary": "Kubernetes healthz endpoint",
-        "description": "An endpoint for health checking used in Kubernetes.",
-        "operationId": "healthz",
-        "tags": ["service"],
-        "responses": {
-          "200": {
-            "description": "Healthz response",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string",
-                  "example": "healthz check passed"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error"
-          }
-        }
-      }
-    },
-    "/livez": {
-      "get": {
-        "summary": "Kubernetes livez endpoint",
-        "description": "An endpoint for health checking used in Kubernetes.",
-        "operationId": "livez",
-        "tags": ["service"],
-        "responses": {
-          "200": {
-            "description": "Healthz response",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string",
-                  "example": "healthz check passed"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error"
-          }
-        }
-      }
-    },
-    "/readyz": {
-      "get": {
-        "summary": "Kubernetes readyz endpoint",
-        "description": "An endpoint for health checking used in Kubernetes.",
-        "operationId": "readyz",
-        "tags": ["service"],
-        "responses": {
-          "200": {
-            "description": "Healthz response",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string",
-                  "example": "healthz check passed"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error"
-          }
-        }
-      }
-    },
-    "/cluster": {
-      "get": {
-        "tags": ["cluster"],
-        "summary": "Get cluster status info",
-        "description": "Get information about the current state and composition of the cluster",
-        "operationId": "cluster_status",
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/ClusterStatus"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/cluster/recover": {
-      "post": {
-        "tags": ["cluster"],
-        "summary": "Tries to recover current peer Raft state.",
-        "operationId": "recover_current_peer",
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/cluster/peer/{peer_id}": {
-      "delete": {
-        "tags": ["cluster"],
-        "summary": "Remove peer from the cluster",
-        "description": "Tries to remove peer from the cluster. Will return an error if peer has shards on it.",
-        "operationId": "remove_peer",
-        "parameters": [
-          {
-            "name": "peer_id",
-            "in": "path",
-            "description": "Id of the peer",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "force",
-            "in": "query",
-            "description": "If true - removes peer even if it has shards/replicas on it.",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections": {
-      "get": {
-        "tags": ["collections"],
-        "summary": "List collections",
-        "description": "Get list name of all existing collections",
-        "operationId": "get_collections",
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/CollectionsResponse"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}": {
-      "get": {
-        "tags": ["collections"],
-        "summary": "Collection info",
-        "description": "Get detailed information about specified existing collection",
-        "operationId": "get_collection",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to retrieve",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/CollectionInfo"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": ["collections"],
-        "summary": "Create collection",
-        "description": "Create new collection with given parameters",
-        "operationId": "create_collection",
-        "requestBody": {
-          "description": "Parameters of a new collection",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateCollection"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the new collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": ["collections"],
-        "summary": "Update collection parameters",
-        "description": "Update parameters of the existing collection",
-        "operationId": "update_collection",
-        "requestBody": {
-          "description": "New parameters",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateCollection"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to update",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["collections"],
-        "summary": "Delete collection",
-        "description": "Drop collection and all associated data",
-        "operationId": "delete_collection",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to delete",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/aliases": {
-      "post": {
-        "tags": ["collections"],
-        "summary": "Update aliases of the collections",
-        "operationId": "update_aliases",
-        "requestBody": {
-          "description": "Alias update operations",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ChangeAliasesOperation"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/index": {
-      "put": {
-        "tags": ["collections"],
-        "summary": "Create index for field in collection",
-        "description": "Create index for field in collection",
-        "operationId": "create_field_index",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "Field name",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateFieldIndex"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/index/{field_name}": {
-      "delete": {
-        "tags": ["collections"],
-        "summary": "Delete index for field in collection",
-        "description": "Delete field index for collection",
-        "operationId": "delete_field_index",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "field_name",
-            "in": "path",
-            "description": "Name of the field where to delete the index",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/cluster": {
-      "get": {
-        "tags": ["collections", "cluster"],
-        "summary": "Collection cluster info",
-        "description": "Get cluster information for a collection",
-        "operationId": "collection_cluster_info",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to retrieve the cluster info for",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/CollectionClusterInfo"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["collections", "cluster"],
-        "summary": "Update collection cluster setup",
-        "operationId": "update_collection_cluster",
-        "requestBody": {
-          "description": "Collection cluster update operations",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ClusterOperations"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection on which to to apply the cluster update operation",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "Wait for operation commit timeout in seconds. \nIf timeout is reached - request will return with service error.\n",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/aliases": {
-      "get": {
-        "tags": ["collections"],
-        "summary": "List aliases for collection",
-        "description": "Get list of all aliases for a collection",
-        "operationId": "get_collection_aliases",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/CollectionsAliasesResponse"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/aliases": {
-      "get": {
-        "tags": ["collections"],
-        "summary": "List collections aliases",
-        "description": "Get list of all existing collections aliases",
-        "operationId": "get_collections_aliases",
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/CollectionsAliasesResponse"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/snapshots/upload": {
-      "post": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Recover from an uploaded snapshot",
-        "description": "Recover local collection data from an uploaded snapshot. This will overwrite any data, stored on this node, for the collection. If collection does not exist - it will be created.",
-        "operationId": "recover_from_uploaded_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "priority",
-            "in": "query",
-            "description": "Defines source of truth for snapshot recovery",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/SnapshotPriority"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "Snapshot to recover from",
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "snapshot": {
-                    "type": "string",
-                    "format": "binary"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/snapshots/recover": {
-      "put": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Recover from a snapshot",
-        "description": "Recover local collection data from a snapshot. This will overwrite any data, stored on this node, for the collection. If collection does not exist - it will be created.",
-        "operationId": "recover_from_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "Snapshot to recover from",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SnapshotRecover"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/snapshots": {
-      "get": {
-        "tags": ["snapshots", "collections"],
-        "summary": "List collection snapshots",
-        "description": "Get list of snapshots for a collection",
-        "operationId": "list_snapshots",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/SnapshotDescription"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Create collection snapshot",
-        "description": "Create new snapshot for a collection",
-        "operationId": "create_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection for which to create a snapshot",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/SnapshotDescription"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/snapshots/{snapshot_name}": {
-      "delete": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Delete collection snapshot",
-        "description": "Delete snapshot for a collection",
-        "operationId": "delete_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection for which to delete a snapshot",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "snapshot_name",
-            "in": "path",
-            "description": "Name of the snapshot to delete",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Download collection snapshot",
-        "description": "Download specified snapshot from a collection as a file",
-        "operationId": "get_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "snapshot_name",
-            "in": "path",
-            "description": "Name of the snapshot to download",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Snapshot file",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/snapshots": {
-      "get": {
-        "tags": ["snapshots"],
-        "summary": "List of storage snapshots",
-        "description": "Get list of snapshots of the whole storage",
-        "operationId": "list_full_snapshots",
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/SnapshotDescription"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["snapshots"],
-        "summary": "Create storage snapshot",
-        "description": "Create new snapshot of the whole storage",
-        "operationId": "create_full_snapshot",
-        "parameters": [
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/SnapshotDescription"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/snapshots/{snapshot_name}": {
-      "delete": {
-        "tags": ["snapshots"],
-        "summary": "Delete storage snapshot",
-        "description": "Delete snapshot of the whole storage",
-        "operationId": "delete_full_snapshot",
-        "parameters": [
-          {
-            "name": "snapshot_name",
-            "in": "path",
-            "description": "Name of the full snapshot to delete",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": ["snapshots"],
-        "summary": "Download storage snapshot",
-        "description": "Download specified snapshot of the whole storage as a file",
-        "operationId": "get_full_snapshot",
-        "parameters": [
-          {
-            "name": "snapshot_name",
-            "in": "path",
-            "description": "Name of the snapshot to download",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Snapshot file",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/shards/{shard_id}/snapshots/upload": {
-      "post": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Recover shard from an uploaded snapshot",
-        "description": "Recover shard of a local collection from an uploaded snapshot. This will overwrite any data, stored on this node, for the collection shard.",
-        "operationId": "recover_shard_from_uploaded_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "shard_id",
-            "in": "path",
-            "description": "Id of the shard to recover",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "priority",
-            "in": "query",
-            "description": "Defines source of truth for snapshot recovery",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/SnapshotPriority"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "Snapshot to recover from",
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "snapshot": {
-                    "type": "string",
-                    "format": "binary"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/shards/{shard_id}/snapshots/recover": {
-      "put": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Recover from a snapshot",
-        "description": "Recover shard of a local collection data from a snapshot. This will overwrite any data, stored in this shard, for the collection.",
-        "operationId": "recover_shard_from_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "shard_id",
-            "in": "path",
-            "description": "Id of the shard to recover",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "requestBody": {
-          "description": "Snapshot to recover from",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ShardSnapshotRecover"
-              }
-            }
-          }
-        },
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/shards/{shard_id}/snapshots": {
-      "get": {
-        "tags": ["snapshots", "collections"],
-        "summary": "List shards snapshots for a collection",
-        "description": "Get list of snapshots for a shard of a collection",
-        "operationId": "list_shard_snapshots",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "shard_id",
-            "in": "path",
-            "description": "Id of the shard",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/SnapshotDescription"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Create shard snapshot",
-        "description": "Create new snapshot of a shard for a collection",
-        "operationId": "create_shard_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection for which to create a snapshot",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "shard_id",
-            "in": "path",
-            "description": "Id of the shard",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/SnapshotDescription"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/shards/{shard_id}/snapshots/{snapshot_name}": {
-      "delete": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Delete shard snapshot",
-        "description": "Delete snapshot of a shard for a collection",
-        "operationId": "delete_shard_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection for which to delete a snapshot",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "shard_id",
-            "in": "path",
-            "description": "Id of the shard",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "snapshot_name",
-            "in": "path",
-            "description": "Name of the snapshot to delete",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen. If false - let changes happen in background. Default is true.",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "operation is accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": ["snapshots", "collections"],
-        "summary": "Download collection snapshot",
-        "description": "Download specified snapshot of a shard from a collection as a file",
-        "operationId": "get_shard_snapshot",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "shard_id",
-            "in": "path",
-            "description": "Id of the shard",
-            "required": true,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "snapshot_name",
-            "in": "path",
-            "description": "Name of the snapshot to download",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "Snapshot file",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/{id}": {
-      "get": {
-        "tags": ["points"],
-        "summary": "Get point",
-        "description": "Retrieve full information of single point by id",
-        "operationId": "get_point",
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to retrieve from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Id of the point",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/Record"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Get points",
-        "description": "Retrieve multiple points by specified IDs",
-        "operationId": "get_points",
-        "requestBody": {
-          "description": "List of points to retrieve",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PointRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to retrieve from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Record"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": ["points"],
-        "summary": "Upsert points",
-        "description": "Perform insert + updates on points. If point with given ID already exists - it will be overwritten.",
-        "operationId": "upsert_points",
-        "requestBody": {
-          "description": "Operation to perform on points",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PointInsertOperations"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to update from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/delete": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Delete points",
-        "description": "Delete points",
-        "operationId": "delete_points",
-        "requestBody": {
-          "description": "Operation to perform on points",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PointsSelector"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to delete from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/vectors": {
-      "put": {
-        "tags": ["points"],
-        "summary": "Update vectors",
-        "description": "Update specified named vectors on points, keep unspecified vectors intact.",
-        "operationId": "update_vectors",
-        "requestBody": {
-          "description": "Update named vectors on points",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateVectors"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to update from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/vectors/delete": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Delete vectors",
-        "description": "Delete named vectors from the given points.",
-        "operationId": "delete_vectors",
-        "requestBody": {
-          "description": "Delete named vectors from points",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DeleteVectors"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to delete from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/payload": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Set payload",
-        "description": "Set payload values for points",
-        "operationId": "set_payload",
-        "requestBody": {
-          "description": "Set payload on points",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetPayload"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to set from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": ["points"],
-        "summary": "Overwrite payload",
-        "description": "Replace full payload of points with new one",
-        "operationId": "overwrite_payload",
-        "requestBody": {
-          "description": "Payload and points selector",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetPayload"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to set from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/payload/delete": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Delete payload",
-        "description": "Delete specified key payload for points",
-        "operationId": "delete_payload",
-        "requestBody": {
-          "description": "delete payload on points",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DeletePayload"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to delete from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/payload/clear": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Clear payload",
-        "description": "Remove all payload for specified points",
-        "operationId": "clear_payload",
-        "requestBody": {
-          "description": "clear payload on points",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PointsSelector"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to clear payload from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/UpdateResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/batch": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Batch update points",
-        "description": "Apply a series of update operations for points, vectors and payloads",
-        "operationId": "batch_update",
-        "requestBody": {
-          "description": "update operations",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateOperations"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to apply operations on",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "wait",
-            "in": "query",
-            "description": "If true, wait for changes to actually happen",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "name": "ordering",
-            "in": "query",
-            "description": "define ordering guarantees for the operation",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/WriteOrdering"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/UpdateResult"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/scroll": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Scroll points",
-        "description": "Scroll request - paginate over all points which matches given filtering condition",
-        "operationId": "scroll_points",
-        "requestBody": {
-          "description": "Pagination and filter parameters",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ScrollRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to retrieve from",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/ScrollResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/search": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Search points",
-        "description": "Retrieve closest points based on vector similarity and given filtering conditions",
-        "operationId": "search_points",
-        "requestBody": {
-          "description": "Search request with optional filtering",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SearchRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ScoredPoint"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/search/batch": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Search batch points",
-        "description": "Retrieve by batch the closest points based on vector similarity and given filtering conditions",
-        "operationId": "search_batch_points",
-        "requestBody": {
-          "description": "Search batch request",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SearchRequestBatch"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/components/schemas/ScoredPoint"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/search/groups": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Search point groups",
-        "description": "Retrieve closest points based on vector similarity and given filtering conditions, grouped by a given payload field",
-        "operationId": "search_point_groups",
-        "requestBody": {
-          "description": "Search request with optional filtering, grouped by a given payload field",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SearchGroupsRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/GroupsResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/recommend": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Recommend points",
-        "description": "Look for the points which are closer to stored positive examples and at the same time further to negative examples.",
-        "operationId": "recommend_points",
-        "requestBody": {
-          "description": "Request points based on positive and negative examples.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RecommendRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ScoredPoint"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/recommend/batch": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Recommend batch points",
-        "description": "Look for the points which are closer to stored positive examples and at the same time further to negative examples.",
-        "operationId": "recommend_batch_points",
-        "requestBody": {
-          "description": "Request points based on positive and negative examples.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RecommendRequestBatch"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/components/schemas/ScoredPoint"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/recommend/groups": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Recommend point groups",
-        "description": "Look for the points which are closer to stored positive examples and at the same time further to negative examples, grouped by a given payload field.",
-        "operationId": "recommend_point_groups",
-        "requestBody": {
-          "description": "Request points based on positive and negative examples, grouped by a payload field.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RecommendGroupsRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/GroupsResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/discover": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Discover points",
-        "description": "Use context and a target to find the most similar points to the target, constrained by the context.\nWhen using only the context (without a target), a special search - called context search - is performed where pairs of points are used to generate a loss that guides the search towards the zone where most positive examples overlap. This means that the score minimizes the scenario of finding a point closer to a negative than to a positive part of a pair.\nSince the score of a context relates to loss, the maximum score a point can get is 0.0, and it becomes normal that many points can have a score of 0.0.\nWhen using target (with or without context), the score behaves a little different: The  integer part of the score represents the rank with respect to the context, while the decimal part of the score relates to the distance to the target. The context part of the score for  each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair,  and -1 otherwise.\n",
-        "operationId": "discover_points",
-        "requestBody": {
-          "description": "Request points based on {positive, negative} pairs of examples, and/or a target",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DiscoverRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/ScoredPoint"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/discover/batch": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Discover batch points",
-        "description": "Look for points based on target and/or positive and negative example pairs, in batch.",
-        "operationId": "discover_batch_points",
-        "requestBody": {
-          "description": "Batch request points based on { positive, negative } pairs of examples, and/or a target.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DiscoverRequestBatch"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to search in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "timeout",
-            "in": "query",
-            "description": "If set, overrides global timeout for this request. Unit is seconds.",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "type": "array",
-                      "items": {
-                        "type": "array",
-                        "items": {
-                          "$ref": "#/components/schemas/ScoredPoint"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/collections/{collection_name}/points/count": {
-      "post": {
-        "tags": ["points"],
-        "summary": "Count points",
-        "description": "Count points which matches given filtering condition",
-        "operationId": "count_points",
-        "requestBody": {
-          "description": "Request counts of points which matches given filtering condition",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CountRequest"
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "name": "collection_name",
-            "in": "path",
-            "description": "Name of the collection to count in",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "description": "error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "time": {
-                      "type": "number",
-                      "format": "float",
-                      "description": "Time spent to process this request"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "result": {
-                      "$ref": "#/components/schemas/CountResult"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "openapi": "3.0.1",
-  "security": [
-    {
-      "api-key": []
-    },
-    {
-      "bearerAuth": []
-    },
-    {}
-  ],
   "info": {
-    "title": "Qdrant API",
-    "description": "API description for Qdrant vector search engine.\n\nThis document describes CRUD and search operations on collections of points (vectors with payload).\n\nQdrant supports any combinations of `should`, `must` and `must_not` conditions, which makes it possible to use in applications when object could not be described solely by vector. It could be location features, availability flags, and other custom properties businesses should take into account.\n## Examples\nThis examples cover the most basic use-cases - collection creation and basic vector search.\n### Create collection\nFirst - let's create a collection with dot-production metric.\n```\ncurl -X PUT 'http://localhost:6333/collections/test_collection' \\\n  -H 'Content-Type: application/json' \\\n  --data-raw '{\n    \"vectors\": {\n      \"size\": 4,\n      \"distance\": \"Dot\"\n    }\n  }'\n\n```\nExpected response:\n```\n{\n    \"result\": true,\n    \"status\": \"ok\",\n    \"time\": 0.031095451\n}\n```\nWe can ensure that collection was created:\n```\ncurl 'http://localhost:6333/collections/test_collection'\n```\nExpected response:\n```\n{\n  \"result\": {\n    \"status\": \"green\",\n    \"vectors_count\": 0,\n    \"segments_count\": 5,\n    \"disk_data_size\": 0,\n    \"ram_data_size\": 0,\n    \"config\": {\n      \"params\": {\n        \"vectors\": {\n          \"size\": 4,\n          \"distance\": \"Dot\"\n        }\n      },\n      \"hnsw_config\": {\n        \"m\": 16,\n        \"ef_construct\": 100,\n        \"full_scan_threshold\": 10000\n      },\n      \"optimizer_config\": {\n        \"deleted_threshold\": 0.2,\n        \"vacuum_min_vector_number\": 1000,\n        \"max_segment_number\": 5,\n        \"memmap_threshold\": 50000,\n        \"indexing_threshold\": 20000,\n        \"flush_interval_sec\": 1\n      },\n      \"wal_config\": {\n        \"wal_capacity_mb\": 32,\n        \"wal_segments_ahead\": 0\n      }\n    }\n  },\n  \"status\": \"ok\",\n  \"time\": 2.1199e-05\n}\n```\n\n### Add points\nLet's now add vectors with some payload:\n```\ncurl -L -X PUT 'http://localhost:6333/collections/test_collection/points?wait=true' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n  \"points\": [\n    {\"id\": 1, \"vector\": [0.05, 0.61, 0.76, 0.74], \"payload\": {\"city\": \"Berlin\"}},\n    {\"id\": 2, \"vector\": [0.19, 0.81, 0.75, 0.11], \"payload\": {\"city\": [\"Berlin\", \"London\"] }},\n    {\"id\": 3, \"vector\": [0.36, 0.55, 0.47, 0.94], \"payload\": {\"city\": [\"Berlin\", \"Moscow\"] }},\n    {\"id\": 4, \"vector\": [0.18, 0.01, 0.85, 0.80], \"payload\": {\"city\": [\"London\", \"Moscow\"] }},\n    {\"id\": 5, \"vector\": [0.24, 0.18, 0.22, 0.44], \"payload\": {\"count\": [0]}},\n    {\"id\": 6, \"vector\": [0.35, 0.08, 0.11, 0.44]}\n  ]\n}'\n```\nExpected response:\n```\n{\n    \"result\": {\n        \"operation_id\": 0,\n        \"status\": \"completed\"\n    },\n    \"status\": \"ok\",\n    \"time\": 0.000206061\n}\n```\n### Search with filtering\nLet's start with a basic request:\n```\ncurl -L -X POST 'http://localhost:6333/collections/test_collection/points/search' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n    \"vector\": [0.2,0.1,0.9,0.7],\n    \"top\": 3\n}'\n```\nExpected response:\n```\n{\n    \"result\": [\n        { \"id\": 4, \"score\": 1.362, \"payload\": null, \"version\": 0 },\n        { \"id\": 1, \"score\": 1.273, \"payload\": null, \"version\": 0 },\n        { \"id\": 3, \"score\": 1.208, \"payload\": null, \"version\": 0 }\n    ],\n    \"status\": \"ok\",\n    \"time\": 0.000055785\n}\n```\nBut result is different if we add a filter:\n```\ncurl -L -X POST 'http://localhost:6333/collections/test_collection/points/search' \\ -H 'Content-Type: application/json' \\ --data-raw '{\n    \"filter\": {\n        \"should\": [\n            {\n                \"key\": \"city\",\n                \"match\": {\n                    \"value\": \"London\"\n                }\n            }\n        ]\n    },\n    \"vector\": [0.2, 0.1, 0.9, 0.7],\n    \"top\": 3\n}'\n```\nExpected response:\n```\n{\n    \"result\": [\n        { \"id\": 4, \"score\": 1.362, \"payload\": null, \"version\": 0 },\n        { \"id\": 2, \"score\": 0.871, \"payload\": null, \"version\": 0 }\n    ],\n    \"status\": \"ok\",\n    \"time\": 0.000093972\n}\n```\n",
+    "version": "1.0.0",
+    "title": "Hookdeck Admin REST API",
+    "termsOfService": "https://hookdeck.com/terms",
     "contact": {
-      "email": "andrey@vasnetsov.com"
-    },
-    "license": {
-      "name": "Apache 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    },
-    "version": "v1.7.x"
-  },
-  "externalDocs": {
-    "description": "Find out more about Qdrant applications and demo",
-    "url": "https://qdrant.tech/documentation/"
-  },
-  "servers": [
-    {
-      "url": "{protocol}://{hostname}:{port}",
-      "variables": {
-        "protocol": {
-          "enum": ["http", "https"],
-          "default": "http"
-        },
-        "hostname": {
-          "default": "localhost"
-        },
-        "port": {
-          "default": "6333"
-        }
-      }
+      "name": "Hookdeck Support",
+      "url": "https://hookdeck.com/contact-us",
+      "email": "info@hookdeck.com"
     }
-  ],
-  "tags": [
-    {
-      "name": "collections",
-      "description": "Searchable collections of points."
-    },
-    {
-      "name": "points",
-      "description": "Float-point vectors with payload."
-    },
-    {
-      "name": "cluster",
-      "description": "Service distributed setup"
-    },
-    {
-      "name": "snapshots",
-      "description": "Storage and collections snapshots"
-    }
-  ],
+  },
   "components": {
     "securitySchemes": {
-      "api-key": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "api-key",
-        "description": "Authorization key, either read-write or read-only"
-      },
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer"
+      },
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
       }
     },
     "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "time": {
-            "type": "number",
-            "format": "float",
-            "description": "Time spent to process this request"
-          },
-          "status": {
-            "type": "object",
-            "properties": {
-              "error": {
-                "type": "string",
-                "description": "Description of the occurred error."
-              }
-            }
-          },
-          "result": {
-            "type": "object",
-            "nullable": true
-          }
-        }
-      },
-      "CollectionsResponse": {
-        "type": "object",
-        "required": ["collections"],
-        "properties": {
-          "collections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CollectionDescription"
-            }
-          }
-        }
-      },
-      "CollectionDescription": {
-        "type": "object",
-        "required": ["name"],
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        }
-      },
-      "CollectionInfo": {
-        "description": "Current statistics and configuration of the collection",
-        "type": "object",
-        "required": [
-          "config",
-          "optimizer_status",
-          "payload_schema",
-          "segments_count",
-          "status"
-        ],
-        "properties": {
-          "status": {
-            "$ref": "#/components/schemas/CollectionStatus"
-          },
-          "optimizer_status": {
-            "$ref": "#/components/schemas/OptimizersStatus"
-          },
-          "vectors_count": {
-            "description": "Approximate number of vectors in collection. All vectors in collection are available for querying. Calculated as `points_count x vectors_per_point`. Where `vectors_per_point` is a number of named vectors in schema.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "indexed_vectors_count": {
-            "description": "Approximate number of indexed vectors in the collection. Indexed vectors in large segments are faster to query, as it is stored in a specialized vector index.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "points_count": {
-            "description": "Approximate number of points (vectors + payloads) in collection. Each point could be accessed by unique id.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "segments_count": {
-            "description": "Number of segments in collection. Each segment has independent vector as payload indexes",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "config": {
-            "$ref": "#/components/schemas/CollectionConfig"
-          },
-          "payload_schema": {
-            "description": "Types of stored payload",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/PayloadIndexInfo"
-            }
-          }
-        }
-      },
-      "CollectionStatus": {
-        "description": "Current state of the collection. `Green` - all good. `Yellow` - optimization is running, `Red` - some operations failed and was not recovered",
-        "type": "string",
-        "enum": ["green", "yellow", "red"]
-      },
-      "OptimizersStatus": {
-        "description": "Current state of the collection",
-        "oneOf": [
+      "OrderByDirection": {
+        "anyOf": [
           {
-            "description": "Optimizers are reporting as expected",
-            "type": "string",
-            "enum": ["ok"]
+            "enum": ["asc"]
           },
           {
-            "description": "Something wrong happened with optimizers",
-            "type": "object",
-            "required": ["error"],
-            "properties": {
-              "error": {
+            "enum": ["desc"]
+          },
+          {
+            "enum": ["ASC"]
+          },
+          {
+            "enum": ["DESC"]
+          }
+        ]
+      },
+      "SeekPagination": {
+        "type": "object",
+        "properties": {
+          "order_by": {
+            "anyOf": [
+              {
                 "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "CollectionConfig": {
-        "type": "object",
-        "required": ["hnsw_config", "optimizer_config", "params", "wal_config"],
-        "properties": {
-          "params": {
-            "$ref": "#/components/schemas/CollectionParams"
-          },
-          "hnsw_config": {
-            "$ref": "#/components/schemas/HnswConfig"
-          },
-          "optimizer_config": {
-            "$ref": "#/components/schemas/OptimizersConfig"
-          },
-          "wal_config": {
-            "$ref": "#/components/schemas/WalConfig"
-          },
-          "quantization_config": {
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QuantizationConfig"
               },
               {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "CollectionParams": {
-        "type": "object",
-        "properties": {
-          "vectors": {
-            "$ref": "#/components/schemas/VectorsConfig"
-          },
-          "shard_number": {
-            "description": "Number of shards the collection has",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1
-          },
-          "sharding_method": {
-            "description": "Sharding method Default is Auto - points are distributed across all available shards Custom - points are distributed across shards according to shard key",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardingMethod"
-              },
-              {
-                "nullable": true
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             ]
           },
-          "replication_factor": {
-            "description": "Number of replicas for each shard",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1
-          },
-          "write_consistency_factor": {
-            "description": "Defines how many replicas should apply the operation for us to consider it successful. Increasing this number will make the collection more resilient to inconsistencies, but will also make it fail if not enough replicas are available. Does not have any performance impact.",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1
-          },
-          "read_fan_out_factor": {
-            "description": "Defines how many additional replicas should be processing read request at the same time. Default value is Auto, which means that fan-out will be determined automatically based on the busyness of the local replica. Having more than 0 might be useful to smooth latency spikes of individual nodes.",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0,
-            "nullable": true
-          },
-          "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
-            "default": false,
-            "type": "boolean"
-          },
-          "sparse_vectors": {
-            "description": "Configuration of the sparse vector storage",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/SparseVectorParams"
-            },
-            "nullable": true
-          }
-        }
-      },
-      "VectorsConfig": {
-        "description": "Vector params separator for single and multiple vector modes Single mode:\n\n{ \"size\": 128, \"distance\": \"Cosine\" }\n\nor multiple mode:\n\n{ \"default\": { \"size\": 128, \"distance\": \"Cosine\" } }",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/VectorParams"
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/VectorParams"
-            }
-          }
-        ]
-      },
-      "VectorParams": {
-        "description": "Params of single vector data storage",
-        "type": "object",
-        "required": ["distance", "size"],
-        "properties": {
-          "size": {
-            "description": "Size of a vectors used",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 1
-          },
-          "distance": {
-            "$ref": "#/components/schemas/Distance"
-          },
-          "hnsw_config": {
-            "description": "Custom params for HNSW index. If none - values from collection configuration are used.",
+          "dir": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/HnswConfigDiff"
+                "$ref": "#/components/schemas/OrderByDirection"
               },
               {
-                "nullable": true
-              }
-            ]
-          },
-          "quantization_config": {
-            "description": "Custom params for quantization. If none - values from collection configuration are used.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QuantizationConfig"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "on_disk": {
-            "description": "If true, vectors are served from disk, improving RAM usage at the cost of latency Default: false",
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "Distance": {
-        "description": "Type of internal tags, build from payload Distance function types used to compare vectors",
-        "type": "string",
-        "enum": ["Cosine", "Euclid", "Dot", "Manhattan"]
-      },
-      "HnswConfigDiff": {
-        "type": "object",
-        "properties": {
-          "m": {
-            "description": "Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "ef_construct": {
-            "description": "Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build the index.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 4,
-            "nullable": true
-          },
-          "full_scan_threshold": {
-            "description": "Minimal size (in kilobytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 10,
-            "nullable": true
-          },
-          "max_indexing_threads": {
-            "description": "Number of parallel threads used for background index building. If 0 - auto selection.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "on_disk": {
-            "description": "Store HNSW index on disk. If set to false, the index will be stored in RAM. Default: false",
-            "type": "boolean",
-            "nullable": true
-          },
-          "payload_m": {
-            "description": "Custom M param for additional payload-aware HNSW links. If not set, default M will be used.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          }
-        }
-      },
-      "QuantizationConfig": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/ScalarQuantization"
-          },
-          {
-            "$ref": "#/components/schemas/ProductQuantization"
-          },
-          {
-            "$ref": "#/components/schemas/BinaryQuantization"
-          }
-        ]
-      },
-      "ScalarQuantization": {
-        "type": "object",
-        "required": ["scalar"],
-        "properties": {
-          "scalar": {
-            "$ref": "#/components/schemas/ScalarQuantizationConfig"
-          }
-        }
-      },
-      "ScalarQuantizationConfig": {
-        "type": "object",
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/ScalarType"
-          },
-          "quantile": {
-            "description": "Quantile for quantization. Expected value range in [0.5, 1.0]. If not set - use the whole range of values",
-            "type": "number",
-            "format": "float",
-            "maximum": 1,
-            "minimum": 0.5,
-            "nullable": true
-          },
-          "always_ram": {
-            "description": "If true - quantized vectors always will be stored in RAM, ignoring the config of main storage",
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "ScalarType": {
-        "type": "string",
-        "enum": ["int8"]
-      },
-      "ProductQuantization": {
-        "type": "object",
-        "required": ["product"],
-        "properties": {
-          "product": {
-            "$ref": "#/components/schemas/ProductQuantizationConfig"
-          }
-        }
-      },
-      "ProductQuantizationConfig": {
-        "type": "object",
-        "required": ["compression"],
-        "properties": {
-          "compression": {
-            "$ref": "#/components/schemas/CompressionRatio"
-          },
-          "always_ram": {
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "CompressionRatio": {
-        "type": "string",
-        "enum": ["x4", "x8", "x16", "x32", "x64"]
-      },
-      "BinaryQuantization": {
-        "type": "object",
-        "required": ["binary"],
-        "properties": {
-          "binary": {
-            "$ref": "#/components/schemas/BinaryQuantizationConfig"
-          }
-        }
-      },
-      "BinaryQuantizationConfig": {
-        "type": "object",
-        "properties": {
-          "always_ram": {
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "ShardingMethod": {
-        "type": "string",
-        "enum": ["auto", "custom"]
-      },
-      "SparseVectorParams": {
-        "description": "Params of single sparse vector data storage",
-        "type": "object",
-        "properties": {
-          "index": {
-            "description": "Custom params for index. If none - values from collection configuration are used.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SparseIndexParams"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "SparseIndexParams": {
-        "description": "Configuration for sparse inverted index.",
-        "type": "object",
-        "properties": {
-          "full_scan_threshold": {
-            "description": "We prefer a full scan search upto (excluding) this number of vectors.\n\nNote: this is number of vectors, not KiloBytes.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "on_disk": {
-            "description": "Store index on disk. If set to false, the index will be stored in RAM. Default: false",
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "HnswConfig": {
-        "description": "Config of HNSW index",
-        "type": "object",
-        "required": ["ef_construct", "full_scan_threshold", "m"],
-        "properties": {
-          "m": {
-            "description": "Number of edges per node in the index graph. Larger the value - more accurate the search, more space required.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "ef_construct": {
-            "description": "Number of neighbours to consider during the index building. Larger the value - more accurate the search, more time required to build index.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 4
-          },
-          "full_scan_threshold": {
-            "description": "Minimal size (in KiloBytes) of vectors for additional payload-based indexing. If payload chunk is smaller than `full_scan_threshold_kb` additional indexing won't be used - in this case full-scan search should be preferred by query planner and additional indexing is not required. Note: 1Kb = 1 vector of size 256",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "max_indexing_threads": {
-            "description": "Number of parallel threads used for background index building. If 0 - auto selection.",
-            "default": 0,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "on_disk": {
-            "description": "Store HNSW index on disk. If set to false, index will be stored in RAM. Default: false",
-            "type": "boolean",
-            "nullable": true
-          },
-          "payload_m": {
-            "description": "Custom M param for hnsw graph built for payload index. If not set, default M will be used.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          }
-        }
-      },
-      "OptimizersConfig": {
-        "type": "object",
-        "required": [
-          "default_segment_number",
-          "deleted_threshold",
-          "flush_interval_sec",
-          "max_optimization_threads",
-          "vacuum_min_vector_number"
-        ],
-        "properties": {
-          "deleted_threshold": {
-            "description": "The minimal fraction of deleted vectors in a segment, required to perform segment optimization",
-            "type": "number",
-            "format": "double",
-            "maximum": 1,
-            "minimum": 0
-          },
-          "vacuum_min_vector_number": {
-            "description": "The minimal number of vectors in a segment, required to perform segment optimization",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 100
-          },
-          "default_segment_number": {
-            "description": "Target amount of segments optimizer will try to keep. Real amount of segments may vary depending on multiple parameters: - Amount of stored points - Current write RPS\n\nIt is recommended to select default number of segments as a factor of the number of search threads, so that each segment would be handled evenly by one of the threads. If `default_segment_number = 0`, will be automatically selected by the number of available CPUs.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "max_segment_size": {
-            "description": "Do not create segments larger this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexing speed is more important - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 If not set, will be automatically selected considering the number of available CPUs.",
-            "default": null,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "memmap_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`. Internally it will use the largest threshold possible.\n\nNote: 1Kb = 1 vector of size 256",
-            "default": null,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "indexing_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`.\n\nNote: 1kB = 1 vector of size 256.",
-            "default": null,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "flush_interval_sec": {
-            "description": "Minimum interval between forced flushes.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "max_optimization_threads": {
-            "description": "Maximum available threads for optimization workers",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          }
-        }
-      },
-      "WalConfig": {
-        "type": "object",
-        "required": ["wal_capacity_mb", "wal_segments_ahead"],
-        "properties": {
-          "wal_capacity_mb": {
-            "description": "Size of a single WAL segment in MB",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1
-          },
-          "wal_segments_ahead": {
-            "description": "Number of WAL segments to create ahead of actually used ones",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          }
-        }
-      },
-      "PayloadIndexInfo": {
-        "description": "Display payload field type & index information",
-        "type": "object",
-        "required": ["data_type", "points"],
-        "properties": {
-          "data_type": {
-            "$ref": "#/components/schemas/PayloadSchemaType"
-          },
-          "params": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PayloadSchemaParams"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "points": {
-            "description": "Number of points indexed with this index",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          }
-        }
-      },
-      "PayloadSchemaType": {
-        "description": "All possible names of payload types",
-        "type": "string",
-        "enum": ["keyword", "integer", "float", "geo", "text", "bool"]
-      },
-      "PayloadSchemaParams": {
-        "description": "Payload type with parameters",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/TextIndexParams"
-          }
-        ]
-      },
-      "TextIndexParams": {
-        "type": "object",
-        "required": ["type"],
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/TextIndexType"
-          },
-          "tokenizer": {
-            "$ref": "#/components/schemas/TokenizerType"
-          },
-          "min_token_len": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "max_token_len": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "lowercase": {
-            "description": "If true, lowercase all tokens. Default: true",
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "TextIndexType": {
-        "type": "string",
-        "enum": ["text"]
-      },
-      "TokenizerType": {
-        "type": "string",
-        "enum": ["prefix", "whitespace", "word", "multilingual"]
-      },
-      "PointRequest": {
-        "type": "object",
-        "required": ["ids"],
-        "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "ids": {
-            "description": "Look for points with ids",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            }
-          },
-          "with_payload": {
-            "description": "Select which payload to return with the response. Default: All",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vector": {
-            "$ref": "#/components/schemas/WithVector"
-          }
-        }
-      },
-      "ShardKeySelector": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/ShardKey"
-          },
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ShardKey"
-            }
-          }
-        ]
-      },
-      "ShardKey": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          }
-        ]
-      },
-      "ExtendedPointId": {
-        "description": "Type, used for specifying point ID in user interface",
-        "anyOf": [
-          {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          {
-            "type": "string",
-            "format": "uuid"
-          }
-        ]
-      },
-      "WithPayloadInterface": {
-        "description": "Options for specifying which payload to include or not",
-        "anyOf": [
-          {
-            "description": "If `true` - return all payload, If `false` - do not return payload",
-            "type": "boolean"
-          },
-          {
-            "description": "Specify which fields to return",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          {
-            "$ref": "#/components/schemas/PayloadSelector"
-          }
-        ]
-      },
-      "PayloadSelector": {
-        "description": "Specifies how to treat payload selector",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/PayloadSelectorInclude"
-          },
-          {
-            "$ref": "#/components/schemas/PayloadSelectorExclude"
-          }
-        ]
-      },
-      "PayloadSelectorInclude": {
-        "type": "object",
-        "required": ["include"],
-        "properties": {
-          "include": {
-            "description": "Only include this payload keys",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "PayloadSelectorExclude": {
-        "type": "object",
-        "required": ["exclude"],
-        "properties": {
-          "exclude": {
-            "description": "Exclude this fields from returning payload",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "WithVector": {
-        "description": "Options for specifying which vector to include",
-        "anyOf": [
-          {
-            "description": "If `true` - return all vector, If `false` - do not return vector",
-            "type": "boolean"
-          },
-          {
-            "description": "Specify which vector to return",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        ]
-      },
-      "Record": {
-        "description": "Point data",
-        "type": "object",
-        "required": ["id"],
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ExtendedPointId"
-          },
-          "payload": {
-            "description": "Payload - values assigned to the point",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Payload"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "vector": {
-            "description": "Vector of the point",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/VectorStruct"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "shard_key": {
-            "description": "Shard Key",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKey"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "Payload": {
-        "type": "object",
-        "additionalProperties": true
-      },
-      "VectorStruct": {
-        "description": "Full vector data per point separator with single and multiple vector modes",
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            }
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/Vector"
-            }
-          }
-        ]
-      },
-      "Vector": {
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            }
-          },
-          {
-            "$ref": "#/components/schemas/SparseVector"
-          }
-        ]
-      },
-      "SparseVector": {
-        "description": "Sparse vector structure",
-        "type": "object",
-        "required": ["indices", "values"],
-        "properties": {
-          "indices": {
-            "description": "indices must be unique",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0
-            }
-          },
-          "values": {
-            "description": "values and indices must be the same length",
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            }
-          }
-        }
-      },
-      "SearchRequest": {
-        "description": "Search request. Holds all conditions and parameters for the search of most similar points by vector similarity given the filtering restrictions.",
-        "type": "object",
-        "required": ["limit", "vector"],
-        "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "vector": {
-            "$ref": "#/components/schemas/NamedVectorStruct"
-          },
-          "filter": {
-            "description": "Look only for points which satisfies this conditions",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "params": {
-            "description": "Additional search params",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SearchParams"
-              },
-              {
-                "nullable": true
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/OrderByDirection"
+                }
               }
             ]
           },
           "limit": {
-            "description": "Max number of result to return",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1
+            "type": "integer"
           },
-          "offset": {
-            "description": "Offset of the first result to return. May be used to paginate results. Note: large offset values may cause performance issues.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "with_payload": {
-            "description": "Select which payload to return with the response. Default: None",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vector": {
-            "description": "Whether to return the point vector with the result?",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "score_threshold": {
-            "description": "Define a minimal score threshold for the result. If defined, less similar results will not be returned. Score of the returned result might be higher or smaller than the threshold depending on the Distance function used. E.g. for cosine similarity only higher scores will be returned.",
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          }
-        }
-      },
-      "NamedVectorStruct": {
-        "description": "Vector data separator for named and unnamed modes Unnamed mode:\n\n{ \"vector\": [1.0, 2.0, 3.0] }\n\nor named mode:\n\n{ \"vector\": { \"vector\": [1.0, 2.0, 3.0], \"name\": \"image-embeddings\" } }",
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            }
-          },
-          {
-            "$ref": "#/components/schemas/NamedVector"
-          },
-          {
-            "$ref": "#/components/schemas/NamedSparseVector"
-          }
-        ]
-      },
-      "NamedVector": {
-        "description": "Vector data with name",
-        "type": "object",
-        "required": ["name", "vector"],
-        "properties": {
-          "name": {
-            "description": "Name of vector data",
+          "prev": {
             "type": "string"
           },
-          "vector": {
-            "description": "Vector data",
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            }
-          }
-        }
-      },
-      "NamedSparseVector": {
-        "description": "Sparse vector data with name",
-        "type": "object",
-        "required": ["name", "vector"],
-        "properties": {
-          "name": {
-            "description": "Name of vector data",
+          "next": {
             "type": "string"
-          },
-          "vector": {
-            "$ref": "#/components/schemas/SparseVector"
-          }
-        }
-      },
-      "Filter": {
-        "type": "object",
-        "properties": {
-          "should": {
-            "description": "At least one of those conditions should match",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Condition"
-            },
-            "nullable": true
-          },
-          "must": {
-            "description": "All conditions must match",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Condition"
-            },
-            "nullable": true
-          },
-          "must_not": {
-            "description": "All conditions must NOT match",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Condition"
-            },
-            "nullable": true
           }
         },
         "additionalProperties": false
       },
-      "Condition": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/FieldCondition"
-          },
-          {
-            "$ref": "#/components/schemas/IsEmptyCondition"
-          },
-          {
-            "$ref": "#/components/schemas/IsNullCondition"
-          },
-          {
-            "$ref": "#/components/schemas/HasIdCondition"
-          },
-          {
-            "$ref": "#/components/schemas/NestedCondition"
-          },
-          {
-            "$ref": "#/components/schemas/Filter"
-          }
-        ]
-      },
-      "FieldCondition": {
-        "description": "All possible payload filtering conditions",
-        "type": "object",
-        "required": ["key"],
-        "properties": {
-          "key": {
-            "description": "Payload key",
-            "type": "string"
-          },
-          "match": {
-            "description": "Check if point has field with a given value",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Match"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "range": {
-            "description": "Check if points value lies in a given range",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Range"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "geo_bounding_box": {
-            "description": "Check if points geo location lies in a given area",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GeoBoundingBox"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "geo_radius": {
-            "description": "Check if geo point is within a given radius",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GeoRadius"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "geo_polygon": {
-            "description": "Check if geo point is within a given polygon",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/GeoPolygon"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "values_count": {
-            "description": "Check number of values of the field",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ValuesCount"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "Match": {
-        "description": "Match filter request",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/MatchValue"
-          },
-          {
-            "$ref": "#/components/schemas/MatchText"
-          },
-          {
-            "$ref": "#/components/schemas/MatchAny"
-          },
-          {
-            "$ref": "#/components/schemas/MatchExcept"
-          }
-        ]
-      },
-      "MatchValue": {
-        "description": "Exact match of the given value",
-        "type": "object",
-        "required": ["value"],
-        "properties": {
-          "value": {
-            "$ref": "#/components/schemas/ValueVariants"
-          }
-        }
-      },
-      "ValueVariants": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "integer",
-            "format": "int64"
-          },
-          {
-            "type": "boolean"
-          }
-        ]
-      },
-      "MatchText": {
-        "description": "Full-text match of the strings.",
-        "type": "object",
-        "required": ["text"],
-        "properties": {
-          "text": {
-            "type": "string"
-          }
-        }
-      },
-      "MatchAny": {
-        "description": "Exact match on any of the given values",
-        "type": "object",
-        "required": ["any"],
-        "properties": {
-          "any": {
-            "$ref": "#/components/schemas/AnyVariants"
-          }
-        }
-      },
-      "AnyVariants": {
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ]
-      },
-      "MatchExcept": {
-        "description": "Should have at least one value not matching the any given values",
-        "type": "object",
-        "required": ["except"],
-        "properties": {
-          "except": {
-            "$ref": "#/components/schemas/AnyVariants"
-          }
-        }
-      },
-      "Range": {
-        "description": "Range filter request",
-        "type": "object",
-        "properties": {
-          "lt": {
-            "description": "point.key < range.lt",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "gt": {
-            "description": "point.key > range.gt",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "gte": {
-            "description": "point.key >= range.gte",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "lte": {
-            "description": "point.key <= range.lte",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          }
-        }
-      },
-      "GeoBoundingBox": {
-        "description": "Geo filter request\n\nMatches coordinates inside the rectangle, described by coordinates of lop-left and bottom-right edges",
-        "type": "object",
-        "required": ["bottom_right", "top_left"],
-        "properties": {
-          "top_left": {
-            "$ref": "#/components/schemas/GeoPoint"
-          },
-          "bottom_right": {
-            "$ref": "#/components/schemas/GeoPoint"
-          }
-        }
-      },
-      "GeoPoint": {
-        "description": "Geo point payload schema",
-        "type": "object",
-        "required": ["lat", "lon"],
-        "properties": {
-          "lon": {
-            "type": "number",
-            "format": "double"
-          },
-          "lat": {
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "GeoRadius": {
-        "description": "Geo filter request\n\nMatches coordinates inside the circle of `radius` and center with coordinates `center`",
-        "type": "object",
-        "required": ["center", "radius"],
-        "properties": {
-          "center": {
-            "$ref": "#/components/schemas/GeoPoint"
-          },
-          "radius": {
-            "description": "Radius of the area in meters",
-            "type": "number",
-            "format": "double"
-          }
-        }
-      },
-      "GeoPolygon": {
-        "description": "Geo filter request\n\nMatches coordinates inside the polygon, defined by `exterior` and `interiors`",
-        "type": "object",
-        "required": ["exterior"],
-        "properties": {
-          "exterior": {
-            "$ref": "#/components/schemas/GeoLineString"
-          },
-          "interiors": {
-            "description": "Interior lines (if present) bound holes within the surface each GeoLineString must consist of a minimum of 4 points, and the first and last points must be the same.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/GeoLineString"
-            },
-            "nullable": true
-          }
-        }
-      },
-      "GeoLineString": {
-        "description": "Ordered sequence of GeoPoints representing the line",
-        "type": "object",
-        "required": ["points"],
-        "properties": {
-          "points": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/GeoPoint"
-            }
-          }
-        }
-      },
-      "ValuesCount": {
-        "description": "Values count filter request",
-        "type": "object",
-        "properties": {
-          "lt": {
-            "description": "point.key.length() < values_count.lt",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "gt": {
-            "description": "point.key.length() > values_count.gt",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "gte": {
-            "description": "point.key.length() >= values_count.gte",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "lte": {
-            "description": "point.key.length() <= values_count.lte",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          }
-        }
-      },
-      "IsEmptyCondition": {
-        "description": "Select points with empty payload for a specified field",
-        "type": "object",
-        "required": ["is_empty"],
-        "properties": {
-          "is_empty": {
-            "$ref": "#/components/schemas/PayloadField"
-          }
-        }
-      },
-      "PayloadField": {
-        "description": "Payload field",
-        "type": "object",
-        "required": ["key"],
-        "properties": {
-          "key": {
-            "description": "Payload field name",
-            "type": "string"
-          }
-        }
-      },
-      "IsNullCondition": {
-        "description": "Select points with null payload for a specified field",
-        "type": "object",
-        "required": ["is_null"],
-        "properties": {
-          "is_null": {
-            "$ref": "#/components/schemas/PayloadField"
-          }
-        }
-      },
-      "HasIdCondition": {
-        "description": "ID-based filtering condition",
-        "type": "object",
-        "required": ["has_id"],
-        "properties": {
-          "has_id": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            },
-            "uniqueItems": true
-          }
-        }
-      },
-      "NestedCondition": {
-        "type": "object",
-        "required": ["nested"],
-        "properties": {
-          "nested": {
-            "$ref": "#/components/schemas/Nested"
-          }
-        }
-      },
-      "Nested": {
-        "description": "Select points with payload for a specified nested field",
-        "type": "object",
-        "required": ["filter", "key"],
-        "properties": {
-          "key": {
-            "type": "string"
-          },
-          "filter": {
-            "$ref": "#/components/schemas/Filter"
-          }
-        }
-      },
-      "SearchParams": {
-        "description": "Additional parameters of the search",
-        "type": "object",
-        "properties": {
-          "hnsw_ef": {
-            "description": "Params relevant to HNSW index Size of the beam in a beam-search. Larger the value - more accurate the result, more time required for search.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "exact": {
-            "description": "Search without approximation. If set to true, search may run long but with exact results.",
-            "default": false,
-            "type": "boolean"
-          },
-          "quantization": {
-            "description": "Quantization params",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QuantizationSearchParams"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "indexed_only": {
-            "description": "If enabled, the engine will only perform search among indexed or small segments. Using this option prevents slow searches in case of delayed index, but does not guarantee that all uploaded vectors will be included in search results",
-            "default": false,
-            "type": "boolean"
-          }
-        }
-      },
-      "QuantizationSearchParams": {
-        "description": "Additional parameters of the search",
-        "type": "object",
-        "properties": {
-          "ignore": {
-            "description": "If true, quantized vectors are ignored. Default is false.",
-            "default": false,
-            "type": "boolean"
-          },
-          "rescore": {
-            "description": "If true, use original vectors to re-score top-k results. Might require more time in case if original vectors are stored on disk. If not set, qdrant decides automatically apply rescoring or not.",
-            "default": null,
-            "type": "boolean",
-            "nullable": true
-          },
-          "oversampling": {
-            "description": "Oversampling factor for quantization. Default is 1.0.\n\nDefines how many extra vectors should be pre-selected using quantized index, and then re-scored using original vectors.\n\nFor example, if `oversampling` is 2.4 and `limit` is 100, then 240 vectors will be pre-selected using quantized index, and then top-100 will be returned after re-scoring.",
-            "default": null,
-            "type": "number",
-            "format": "double",
-            "minimum": 1,
-            "nullable": true
-          }
-        }
-      },
-      "ScoredPoint": {
-        "description": "Search result",
-        "type": "object",
-        "required": ["id", "score", "version"],
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/ExtendedPointId"
-          },
-          "version": {
-            "description": "Point version",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "score": {
-            "description": "Points vector distance to the query vector",
-            "type": "number",
-            "format": "float"
-          },
-          "payload": {
-            "description": "Payload - values assigned to the point",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Payload"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "vector": {
-            "description": "Vector of the point",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/VectorStruct"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "shard_key": {
-            "description": "Shard Key",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKey"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "UpdateResult": {
-        "type": "object",
-        "required": ["status"],
-        "properties": {
-          "operation_id": {
-            "description": "Sequential number of the operation",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0,
-            "nullable": true
-          },
-          "status": {
-            "$ref": "#/components/schemas/UpdateStatus"
-          }
-        }
-      },
-      "UpdateStatus": {
-        "description": "`Acknowledged` - Request is saved to WAL and will be process in a queue. `Completed` - Request is completed, changes are actual.",
+      "IssueType": {
         "type": "string",
-        "enum": ["acknowledged", "completed"]
+        "enum": ["delivery", "transformation", "backpressure"],
+        "description": "Issue type"
       },
-      "RecommendRequest": {
-        "description": "Recommendation request. Provides positive and negative examples of the vectors, which can be ids of points that are already stored in the collection, raw vectors, or even ids and vectors combined.\n\nService should look for the points which are closer to positive examples and at the same time further to negative examples. The concrete way of how to compare negative and positive distances is up to the `strategy` chosen.",
+      "IssueTriggerStrategy": {
+        "type": "string",
+        "enum": ["first_attempt", "final_attempt"],
+        "description": "The strategy uses to open the issue"
+      },
+      "IssueTriggerDeliveryConfigs": {
         "type": "object",
-        "required": ["limit"],
         "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "positive": {
-            "description": "Look for vectors closest to those",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RecommendExample"
-            }
-          },
-          "negative": {
-            "description": "Try to avoid vectors like this",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RecommendExample"
-            }
-          },
           "strategy": {
-            "description": "How to use positive and negative examples to find the results",
+            "$ref": "#/components/schemas/IssueTriggerStrategy"
+          },
+          "connections": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/RecommendStrategy"
+                "type": "string"
               },
               {
-                "nullable": true
-              }
-            ]
-          },
-          "filter": {
-            "description": "Look only for points which satisfies this conditions",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "params": {
-            "description": "Additional search params",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SearchParams"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "limit": {
-            "description": "Max number of result to return",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1
-          },
-          "offset": {
-            "description": "Offset of the first result to return. May be used to paginate results. Note: large offset values may cause performance issues.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "with_payload": {
-            "description": "Select which payload to return with the response. Default: None",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vector": {
-            "description": "Whether to return the point vector with the result?",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "score_threshold": {
-            "description": "Define a minimal score threshold for the result. If defined, less similar results will not be returned. Score of the returned result might be higher or smaller than the threshold depending on the Distance function used. E.g. for cosine similarity only higher scores will be returned.",
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          },
-          "using": {
-            "description": "Define which vector to use for recommendation, if not specified - try to use default vector",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UsingVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "lookup_from": {
-            "description": "The location used to lookup vectors. If not specified - use current collection. Note: the other collection should have the same vector size as the current collection",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/LookupLocation"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "RecommendExample": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/ExtendedPointId"
-          },
-          {
-            "type": "array",
-            "items": {
-              "type": "number",
-              "format": "float"
-            }
-          },
-          {
-            "$ref": "#/components/schemas/SparseVector"
-          }
-        ]
-      },
-      "RecommendStrategy": {
-        "description": "How to use positive and negative examples to find the results, default is `average_vector`:\n\n* `average_vector` - Average positive and negative vectors and create a single query with the formula `query = avg_pos + avg_pos - avg_neg`. Then performs normal search.\n\n* `best_score` - Uses custom search objective. Each candidate is compared against all examples, its score is then chosen from the `max(max_pos_score, max_neg_score)`. If the `max_neg_score` is chosen then it is squared and negated, otherwise it is just the `max_pos_score`.",
-        "type": "string",
-        "enum": ["average_vector", "best_score"]
-      },
-      "UsingVector": {
-        "anyOf": [
-          {
-            "type": "string"
-          }
-        ]
-      },
-      "LookupLocation": {
-        "description": "Defines a location to use for looking up the vector. Specifies collection and vector field name.",
-        "type": "object",
-        "required": ["collection"],
-        "properties": {
-          "collection": {
-            "description": "Name of the collection used for lookup",
-            "type": "string"
-          },
-          "vector": {
-            "description": "Optional name of the vector field within the collection. If not provided, the default vector field will be used.",
-            "default": null,
-            "type": "string",
-            "nullable": true
-          },
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "ScrollRequest": {
-        "description": "Scroll request - paginate over all points which matches given condition",
-        "type": "object",
-        "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "offset": {
-            "description": "Start ID to read points from.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ExtendedPointId"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "limit": {
-            "description": "Page size. Default: 10",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1,
-            "nullable": true
-          },
-          "filter": {
-            "description": "Look only for points which satisfies this conditions. If not provided - all points.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_payload": {
-            "description": "Select which payload to return with the response. Default: All",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vector": {
-            "$ref": "#/components/schemas/WithVector"
-          }
-        }
-      },
-      "ScrollResult": {
-        "description": "Result of the points read request",
-        "type": "object",
-        "required": ["points"],
-        "properties": {
-          "points": {
-            "description": "List of retrieved points",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Record"
-            }
-          },
-          "next_page_offset": {
-            "description": "Offset which should be used to retrieve a next page result",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ExtendedPointId"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "CreateCollection": {
-        "description": "Operation for creating new collection and (optionally) specify index params",
-        "type": "object",
-        "properties": {
-          "vectors": {
-            "$ref": "#/components/schemas/VectorsConfig"
-          },
-          "shard_number": {
-            "description": "For auto sharding: Number of shards in collection. - Default is 1 for standalone, otherwise equal to the number of nodes - Minimum is 1 For custom sharding: Number of shards in collection per shard group. - Default is 1, meaning that each shard key will be mapped to a single shard - Minimum is 1",
-            "default": null,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1,
-            "nullable": true
-          },
-          "sharding_method": {
-            "description": "Sharding method Default is Auto - points are distributed across all available shards Custom - points are distributed across shards according to shard key",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardingMethod"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "replication_factor": {
-            "description": "Number of shards replicas. Default is 1 Minimum is 1",
-            "default": null,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1,
-            "nullable": true
-          },
-          "write_consistency_factor": {
-            "description": "Defines how many replicas should apply the operation for us to consider it successful. Increasing this number will make the collection more resilient to inconsistencies, but will also make it fail if not enough replicas are available. Does not have any performance impact.",
-            "default": null,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1,
-            "nullable": true
-          },
-          "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
-            "default": null,
-            "type": "boolean",
-            "nullable": true
-          },
-          "hnsw_config": {
-            "description": "Custom params for HNSW index. If none - values from service configuration file are used.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/HnswConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "wal_config": {
-            "description": "Custom params for WAL. If none - values from service configuration file are used.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WalConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "optimizers_config": {
-            "description": "Custom params for Optimizers.  If none - values from service configuration file are used.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OptimizersConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "init_from": {
-            "description": "Specify other collection to copy data from.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/InitFrom"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "quantization_config": {
-            "description": "Quantization parameters. If none - quantization is disabled.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QuantizationConfig"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "sparse_vectors": {
-            "description": "Sparse vector data config.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/SparseVectorParams"
-            },
-            "nullable": true
-          }
-        }
-      },
-      "WalConfigDiff": {
-        "type": "object",
-        "properties": {
-          "wal_capacity_mb": {
-            "description": "Size of a single WAL segment in MB",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1,
-            "nullable": true
-          },
-          "wal_segments_ahead": {
-            "description": "Number of WAL segments to create ahead of actually used ones",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          }
-        }
-      },
-      "OptimizersConfigDiff": {
-        "type": "object",
-        "properties": {
-          "deleted_threshold": {
-            "description": "The minimal fraction of deleted vectors in a segment, required to perform segment optimization",
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "vacuum_min_vector_number": {
-            "description": "The minimal number of vectors in a segment, required to perform segment optimization",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "default_segment_number": {
-            "description": "Target amount of segments optimizer will try to keep. Real amount of segments may vary depending on multiple parameters: - Amount of stored points - Current write RPS\n\nIt is recommended to select default number of segments as a factor of the number of search threads, so that each segment would be handled evenly by one of the threads If `default_segment_number = 0`, will be automatically selected by the number of available CPUs",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "max_segment_size": {
-            "description": "Do not create segments larger this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "memmap_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors to store in-memory per segment. Segments larger than this threshold will be stored as read-only memmaped file.\n\nMemmap storage is disabled by default, to enable it, set this threshold to a reasonable value.\n\nTo disable memmap storage, set this to `0`.\n\nNote: 1Kb = 1 vector of size 256",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "indexing_threshold": {
-            "description": "Maximum size (in kilobytes) of vectors allowed for plain index, exceeding this threshold will enable vector indexing\n\nDefault value is 20,000, based on <https://github.com/google-research/google-research/blob/master/scann/docs/algorithms.md>.\n\nTo disable vector indexing, set to `0`.\n\nNote: 1kB = 1 vector of size 256.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "flush_interval_sec": {
-            "description": "Minimum interval between forced flushes.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0,
-            "nullable": true
-          },
-          "max_optimization_threads": {
-            "description": "Maximum available threads for optimization workers",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          }
-        }
-      },
-      "InitFrom": {
-        "description": "Operation for creating new collection and (optionally) specify index params",
-        "type": "object",
-        "required": ["collection"],
-        "properties": {
-          "collection": {
-            "type": "string"
-          }
-        }
-      },
-      "UpdateCollection": {
-        "description": "Operation for updating parameters of the existing collection",
-        "type": "object",
-        "properties": {
-          "vectors": {
-            "description": "Map of vector data parameters to update for each named vector. To update parameters in a collection having a single unnamed vector, use an empty string as name.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/VectorsConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "optimizers_config": {
-            "description": "Custom params for Optimizers.  If none - it is left unchanged. This operation is blocking, it will only proceed once all current optimizations are complete",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OptimizersConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "params": {
-            "description": "Collection base params. If none - it is left unchanged.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/CollectionParamsDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "hnsw_config": {
-            "description": "HNSW parameters to update for the collection index. If none - it is left unchanged.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/HnswConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "quantization_config": {
-            "description": "Quantization parameters to update. If none - it is left unchanged.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QuantizationConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "sparse_vectors": {
-            "description": "Map of sparse vector data parameters to update for each sparse vector.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SparseVectorsConfig"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "VectorsConfigDiff": {
-        "description": "Vector update params for multiple vectors\n\n{ \"vector_name\": { \"hnsw_config\": { \"m\": 8 } } }",
-        "type": "object",
-        "additionalProperties": {
-          "$ref": "#/components/schemas/VectorParamsDiff"
-        }
-      },
-      "VectorParamsDiff": {
-        "type": "object",
-        "properties": {
-          "hnsw_config": {
-            "description": "Update params for HNSW index. If empty object - it will be unset.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/HnswConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "quantization_config": {
-            "description": "Update params for quantization. If none - it is left unchanged.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QuantizationConfigDiff"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "on_disk": {
-            "description": "If true, vectors are served from disk, improving RAM usage at the cost of latency",
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "QuantizationConfigDiff": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/ScalarQuantization"
-          },
-          {
-            "$ref": "#/components/schemas/ProductQuantization"
-          },
-          {
-            "$ref": "#/components/schemas/BinaryQuantization"
-          },
-          {
-            "$ref": "#/components/schemas/Disabled"
-          }
-        ]
-      },
-      "Disabled": {
-        "type": "string",
-        "enum": ["Disabled"]
-      },
-      "CollectionParamsDiff": {
-        "type": "object",
-        "properties": {
-          "replication_factor": {
-            "description": "Number of replicas for each shard",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1,
-            "nullable": true
-          },
-          "write_consistency_factor": {
-            "description": "Minimal number successful responses from replicas to consider operation successful",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1,
-            "nullable": true
-          },
-          "read_fan_out_factor": {
-            "description": "Fan-out every read request to these many additional remote nodes (and return first available response)",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0,
-            "nullable": true
-          },
-          "on_disk_payload": {
-            "description": "If true - point's payload will not be stored in memory. It will be read from the disk every time it is requested. This setting saves RAM by (slightly) increasing the response time. Note: those payload values that are involved in filtering and are indexed - remain in RAM.",
-            "default": null,
-            "type": "boolean",
-            "nullable": true
-          }
-        }
-      },
-      "SparseVectorsConfig": {
-        "type": "object",
-        "additionalProperties": {
-          "$ref": "#/components/schemas/SparseVectorParams"
-        }
-      },
-      "ChangeAliasesOperation": {
-        "description": "Operation for performing changes of collection aliases. Alias changes are atomic, meaning that no collection modifications can happen between alias operations.",
-        "type": "object",
-        "required": ["actions"],
-        "properties": {
-          "actions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AliasOperations"
-            }
-          }
-        }
-      },
-      "AliasOperations": {
-        "description": "Group of all the possible operations related to collection aliases",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/CreateAliasOperation"
-          },
-          {
-            "$ref": "#/components/schemas/DeleteAliasOperation"
-          },
-          {
-            "$ref": "#/components/schemas/RenameAliasOperation"
-          }
-        ]
-      },
-      "CreateAliasOperation": {
-        "type": "object",
-        "required": ["create_alias"],
-        "properties": {
-          "create_alias": {
-            "$ref": "#/components/schemas/CreateAlias"
-          }
-        }
-      },
-      "CreateAlias": {
-        "description": "Create alternative name for a collection. Collection will be available under both names for search, retrieve,",
-        "type": "object",
-        "required": ["alias_name", "collection_name"],
-        "properties": {
-          "collection_name": {
-            "type": "string"
-          },
-          "alias_name": {
-            "type": "string"
-          }
-        }
-      },
-      "DeleteAliasOperation": {
-        "description": "Delete alias if exists",
-        "type": "object",
-        "required": ["delete_alias"],
-        "properties": {
-          "delete_alias": {
-            "$ref": "#/components/schemas/DeleteAlias"
-          }
-        }
-      },
-      "DeleteAlias": {
-        "description": "Delete alias if exists",
-        "type": "object",
-        "required": ["alias_name"],
-        "properties": {
-          "alias_name": {
-            "type": "string"
-          }
-        }
-      },
-      "RenameAliasOperation": {
-        "description": "Change alias to a new one",
-        "type": "object",
-        "required": ["rename_alias"],
-        "properties": {
-          "rename_alias": {
-            "$ref": "#/components/schemas/RenameAlias"
-          }
-        }
-      },
-      "RenameAlias": {
-        "description": "Change alias to a new one",
-        "type": "object",
-        "required": ["new_alias_name", "old_alias_name"],
-        "properties": {
-          "old_alias_name": {
-            "type": "string"
-          },
-          "new_alias_name": {
-            "type": "string"
-          }
-        }
-      },
-      "CreateFieldIndex": {
-        "type": "object",
-        "required": ["field_name"],
-        "properties": {
-          "field_name": {
-            "type": "string"
-          },
-          "field_schema": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PayloadFieldSchema"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "PayloadFieldSchema": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/PayloadSchemaType"
-          },
-          {
-            "$ref": "#/components/schemas/PayloadSchemaParams"
-          }
-        ]
-      },
-      "PointsSelector": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/PointIdsList"
-          },
-          {
-            "$ref": "#/components/schemas/FilterSelector"
-          }
-        ]
-      },
-      "PointIdsList": {
-        "type": "object",
-        "required": ["points"],
-        "properties": {
-          "points": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            }
-          },
-          "shard_key": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "FilterSelector": {
-        "type": "object",
-        "required": ["filter"],
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/Filter"
-          },
-          "shard_key": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "PointInsertOperations": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/PointsBatch"
-          },
-          {
-            "$ref": "#/components/schemas/PointsList"
-          }
-        ]
-      },
-      "PointsBatch": {
-        "type": "object",
-        "required": ["batch"],
-        "properties": {
-          "batch": {
-            "$ref": "#/components/schemas/Batch"
-          },
-          "shard_key": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "Batch": {
-        "type": "object",
-        "required": ["ids", "vectors"],
-        "properties": {
-          "ids": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            }
-          },
-          "vectors": {
-            "$ref": "#/components/schemas/BatchVectorStruct"
-          },
-          "payloads": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/Payload"
-                },
-                {
-                  "nullable": true
+                "type": "array",
+                "items": {
+                  "type": "string"
                 }
-              ]
-            },
-            "nullable": true
-          }
-        }
-      },
-      "BatchVectorStruct": {
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "array",
-              "items": {
-                "type": "number",
-                "format": "float"
               }
-            }
-          },
-          {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Vector"
-              }
-            }
+            ],
+            "description": "A pattern to match on the connection name or array of connection IDs. Use `*` as wildcard.",
+            "x-docs-force-simple-type": true
           }
-        ]
+        },
+        "required": ["strategy", "connections"],
+        "additionalProperties": false,
+        "description": "Configurations for a 'delivery' issue trigger"
       },
-      "PointsList": {
+      "TransformationExecutionLogLevel": {
+        "type": "string",
+        "enum": ["debug", "info", "warn", "error", "fatal"],
+        "description": "The minimum log level to open the issue on"
+      },
+      "IssueTriggerTransformationConfigs": {
         "type": "object",
-        "required": ["points"],
         "properties": {
-          "points": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PointStruct"
-            }
+          "log_level": {
+            "$ref": "#/components/schemas/TransformationExecutionLogLevel"
           },
-          "shard_key": {
+          "transformations": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ShardKeySelector"
+                "type": "string"
               },
               {
-                "nullable": true
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
-            ]
+            ],
+            "description": "A pattern to match on the transformation name or array of transformation IDs. Use `*` as wildcard.",
+            "x-docs-force-simple-type": true
           }
-        }
+        },
+        "required": ["log_level", "transformations"],
+        "additionalProperties": false,
+        "description": "Configurations for a 'Transformation' issue trigger"
       },
-      "PointStruct": {
+      "IssueTriggerBackpressureDelay": {
+        "type": "integer",
+        "minimum": 60000,
+        "maximum": 86400000,
+        "description": "The minimum delay (backpressure) to open the issue for min of 1 minute (60000) and max of 1 day (86400000)",
+        "x-docs-type": "integer"
+      },
+      "IssueTriggerBackpressureConfigs": {
         "type": "object",
-        "required": ["id", "vector"],
+        "properties": {
+          "delay": {
+            "$ref": "#/components/schemas/IssueTriggerBackpressureDelay"
+          },
+          "destinations": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "description": "A pattern to match on the destination name or array of destination IDs. Use `*` as wildcard.",
+            "x-docs-force-simple-type": true
+          }
+        },
+        "required": ["delay", "destinations"],
+        "additionalProperties": false,
+        "description": "Configurations for a 'Backpressure' issue trigger"
+      },
+      "IssueTriggerReference": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/IssueTriggerDeliveryConfigs"
+          },
+          {
+            "$ref": "#/components/schemas/IssueTriggerTransformationConfigs"
+          },
+          {
+            "$ref": "#/components/schemas/IssueTriggerBackpressureConfigs"
+          }
+        ],
+        "description": "Configuration object for the specific issue type selected"
+      },
+      "IssueTriggerSlackChannel": {
+        "type": "object",
+        "properties": {
+          "channel_name": {
+            "type": "string",
+            "description": "Channel name"
+          }
+        },
+        "required": ["channel_name"],
+        "additionalProperties": false,
+        "description": "Slack channel for an issue trigger",
+        "x-docs-type": "object"
+      },
+      "IssueTriggerIntegrationChannel": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "Integration channel for an issue trigger",
+        "x-docs-type": "object"
+      },
+      "IssueTriggerEmailChannel": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "Email channel for an issue trigger",
+        "x-docs-type": "object"
+      },
+      "IssueTriggerChannels": {
+        "type": "object",
+        "properties": {
+          "slack": {
+            "$ref": "#/components/schemas/IssueTriggerSlackChannel"
+          },
+          "opsgenie": {
+            "$ref": "#/components/schemas/IssueTriggerIntegrationChannel"
+          },
+          "email": {
+            "$ref": "#/components/schemas/IssueTriggerEmailChannel"
+          }
+        },
+        "additionalProperties": false,
+        "nullable": true,
+        "description": "Notification channels object for the specific channel type"
+      },
+      "IssueTrigger": {
+        "type": "object",
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ExtendedPointId"
-          },
-          "vector": {
-            "$ref": "#/components/schemas/VectorStruct"
-          },
-          "payload": {
-            "description": "Payload values (optional)",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Payload"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "SetPayload": {
-        "description": "This data structure is used in API interface and applied across multiple shards",
-        "type": "object",
-        "required": ["payload"],
-        "properties": {
-          "payload": {
-            "$ref": "#/components/schemas/Payload"
-          },
-          "points": {
-            "description": "Assigns payload to each point in this list",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            },
-            "nullable": true
-          },
-          "filter": {
-            "description": "Assigns payload to each point that satisfy this filter condition",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "shard_key": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "DeletePayload": {
-        "description": "This data structure is used in API interface and applied across multiple shards",
-        "type": "object",
-        "required": ["keys"],
-        "properties": {
-          "keys": {
-            "description": "List of payload keys to remove from payload",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "points": {
-            "description": "Deletes values from each point in this list",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            },
-            "nullable": true
-          },
-          "filter": {
-            "description": "Deletes values from points that satisfy this filter condition",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "shard_key": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "ClusterStatus": {
-        "description": "Information about current cluster status and structure",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["status"],
-            "properties": {
-              "status": {
-                "type": "string",
-                "enum": ["disabled"]
-              }
-            }
-          },
-          {
-            "description": "Description of enabled cluster",
-            "type": "object",
-            "required": [
-              "consensus_thread_status",
-              "message_send_failures",
-              "peer_id",
-              "peers",
-              "raft_info",
-              "status"
-            ],
-            "properties": {
-              "status": {
-                "type": "string",
-                "enum": ["enabled"]
-              },
-              "peer_id": {
-                "description": "ID of this peer",
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0
-              },
-              "peers": {
-                "description": "Peers composition of the cluster with main information",
-                "type": "object",
-                "additionalProperties": {
-                  "$ref": "#/components/schemas/PeerInfo"
-                }
-              },
-              "raft_info": {
-                "$ref": "#/components/schemas/RaftInfo"
-              },
-              "consensus_thread_status": {
-                "$ref": "#/components/schemas/ConsensusThreadStatus"
-              },
-              "message_send_failures": {
-                "description": "Consequent failures of message send operations in consensus by peer address. On the first success to send to that peer - entry is removed from this hashmap.",
-                "type": "object",
-                "additionalProperties": {
-                  "$ref": "#/components/schemas/MessageSendErrors"
-                }
-              }
-            }
-          }
-        ]
-      },
-      "PeerInfo": {
-        "description": "Information of a peer in the cluster",
-        "type": "object",
-        "required": ["uri"],
-        "properties": {
-          "uri": {
-            "type": "string"
-          }
-        }
-      },
-      "RaftInfo": {
-        "description": "Summary information about the current raft state",
-        "type": "object",
-        "required": ["commit", "is_voter", "pending_operations", "term"],
-        "properties": {
-          "term": {
-            "description": "Raft divides time into terms of arbitrary length, each beginning with an election. If a candidate wins the election, it remains the leader for the rest of the term. The term number increases monotonically. Each server stores the current term number which is also exchanged in every communication.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "commit": {
-            "description": "The index of the latest committed (finalized) operation that this peer is aware of.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "pending_operations": {
-            "description": "Number of consensus operations pending to be applied on this peer",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "leader": {
-            "description": "Leader of the current term",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0,
-            "nullable": true
-          },
-          "role": {
-            "description": "Role of this peer in the current term",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/StateRole"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "is_voter": {
-            "description": "Is this peer a voter or a learner",
-            "type": "boolean"
-          }
-        }
-      },
-      "StateRole": {
-        "description": "Role of the peer in the consensus",
-        "type": "string",
-        "enum": ["Follower", "Candidate", "Leader", "PreCandidate"]
-      },
-      "ConsensusThreadStatus": {
-        "description": "Information about current consensus thread status",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["consensus_thread_status", "last_update"],
-            "properties": {
-              "consensus_thread_status": {
-                "type": "string",
-                "enum": ["working"]
-              },
-              "last_update": {
-                "type": "string",
-                "format": "date-time"
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": ["consensus_thread_status"],
-            "properties": {
-              "consensus_thread_status": {
-                "type": "string",
-                "enum": ["stopped"]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": ["consensus_thread_status", "err"],
-            "properties": {
-              "consensus_thread_status": {
-                "type": "string",
-                "enum": ["stopped_with_err"]
-              },
-              "err": {
-                "type": "string"
-              }
-            }
-          }
-        ]
-      },
-      "MessageSendErrors": {
-        "description": "Message send failures for a particular peer",
-        "type": "object",
-        "required": ["count"],
-        "properties": {
-          "count": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "latest_error": {
             "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "SnapshotDescription": {
-        "type": "object",
-        "required": ["name", "size"],
-        "properties": {
+            "description": "ID of the issue trigger"
+          },
+          "team_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the workspace"
+          },
           "name": {
-            "type": "string"
-          },
-          "creation_time": {
             "type": "string",
-            "format": "partial-date-time",
-            "nullable": true
+            "nullable": true,
+            "description": "Optional unique name to use as reference when using the API"
           },
-          "size": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
+          "type": {
+            "$ref": "#/components/schemas/IssueType"
+          },
+          "configs": {
+            "$ref": "#/components/schemas/IssueTriggerReference"
+          },
+          "channels": {
+            "$ref": "#/components/schemas/IssueTriggerChannels"
+          },
+          "disabled_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp for when the issue trigger was disabled"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue trigger was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue trigger was created"
+          },
+          "deleted_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp for when the issue trigger was deleted"
           }
-        }
+        },
+        "required": ["id", "type", "configs", "updated_at", "created_at"],
+        "additionalProperties": false
       },
-      "CountRequest": {
-        "description": "Count Request Counts the number of points which satisfy the given filter. If filter is not provided, the count of all points in the collection will be returned.",
+      "IssueTriggerPaginatedResult": {
         "type": "object",
         "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
           },
-          "filter": {
-            "description": "Look only for points which satisfies this conditions",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "exact": {
-            "description": "If true, count exact number of points. If false, count approximate number of points faster. Approximate count might be unreliable during the indexing process. Default: true",
-            "default": true,
-            "type": "boolean"
-          }
-        }
-      },
-      "CountResult": {
-        "type": "object",
-        "required": ["count"],
-        "properties": {
           "count": {
-            "description": "Number of points which satisfy the conditions",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IssueTrigger"
+            }
           }
-        }
+        },
+        "additionalProperties": false
       },
-      "CollectionClusterInfo": {
-        "description": "Current clustering distribution for the collection",
+      "APIErrorResponse": {
         "type": "object",
-        "required": [
-          "local_shards",
-          "peer_id",
-          "remote_shards",
-          "shard_count",
-          "shard_transfers"
-        ],
         "properties": {
-          "peer_id": {
-            "description": "ID of this peer",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
+          "code": {
+            "type": "string",
+            "description": "Error code"
           },
-          "shard_count": {
-            "description": "Total number of shards",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+          "status": {
+            "type": "number",
+            "format": "float",
+            "description": "Status code"
           },
-          "local_shards": {
-            "description": "Local shards",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LocalShardInfo"
-            }
+          "message": {
+            "type": "string",
+            "description": "Error description"
           },
-          "remote_shards": {
-            "description": "Remote shards",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RemoteShardInfo"
-            }
-          },
-          "shard_transfers": {
-            "description": "Shard transfers",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ShardTransferInfo"
-            }
+          "data": {
+            "type": "object",
+            "properties": {},
+            "nullable": true
           }
-        }
+        },
+        "required": ["code", "status", "message"],
+        "additionalProperties": false,
+        "description": "Error response model"
       },
-      "LocalShardInfo": {
+      "DeletedIssueTriggerResponse": {
         "type": "object",
-        "required": ["points_count", "shard_id", "state"],
         "properties": {
-          "shard_id": {
-            "description": "Local shard id",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "shard_key": {
-            "description": "User-defined sharding key",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKey"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "points_count": {
-            "description": "Number of points in the shard",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "state": {
-            "$ref": "#/components/schemas/ReplicaState"
+          "id": {
+            "type": "string"
           }
-        }
+        },
+        "required": ["id"],
+        "additionalProperties": false
       },
-      "ReplicaState": {
-        "description": "State of the single shard within a replica set.",
+      "AttemptTrigger": {
+        "type": "string",
+        "enum": ["INITIAL", "MANUAL", "BULK_RETRY", "UNPAUSE", "AUTOMATIC"],
+        "nullable": true,
+        "description": "How the attempt was triggered"
+      },
+      "AttemptErrorCodes": {
         "type": "string",
         "enum": [
-          "Active",
-          "Dead",
-          "Partial",
-          "Initializing",
-          "Listener",
-          "PartialSnapshot"
-        ]
+          "CANCELLED",
+          "TIMEOUT",
+          "NOT_FOUND",
+          "CONNECTION_REFUSED",
+          "CONNECTION_RESET",
+          "MISSING_URL",
+          "CLI",
+          "CLI_UNAVAILABLE",
+          "SELF_SIGNED_CERT",
+          "ERR_TLS_CERT_ALTNAME_INVALID",
+          "ERR_SSL_WRONG_VERSION_NUMBER",
+          "SSL_ERROR_CA_UNKNOWN",
+          "TTL_EXPIRED",
+          "DATA_ARCHIVED",
+          "SSL_CERT_EXPIRED",
+          "BULK_RETRY_CANCELLED",
+          "DNS_LOOKUP_FAILED",
+          "HOST_UNREACHABLE",
+          "PROTOCOL_ERROR",
+          "SOCKET_CLOSED",
+          "OAUTH2_HANDSHAKE_FAILED",
+          "UNKNOWN"
+        ],
+        "description": "Error code of the delivery attempt"
       },
-      "RemoteShardInfo": {
+      "AttemptStatus": {
+        "type": "string",
+        "enum": ["QUEUED", "FAILED", "SUCCESSFUL", "HOLD"],
+        "description": "Attempt status"
+      },
+      "AttemptState": {
+        "type": "string",
+        "enum": ["DELIVERING", "QUEUED", "PENDING", "COMPLETED", "HOLD"],
+        "nullable": true,
+        "x-docs-hide": true
+      },
+      "EventAttempt": {
         "type": "object",
-        "required": ["peer_id", "shard_id", "state"],
-        "properties": {
-          "shard_id": {
-            "description": "Remote shard id",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "shard_key": {
-            "description": "User-defined sharding key",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKey"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "peer_id": {
-            "description": "Remote peer id",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "state": {
-            "$ref": "#/components/schemas/ReplicaState"
-          }
-        }
-      },
-      "ShardTransferInfo": {
-        "type": "object",
-        "required": ["from", "shard_id", "sync", "to"],
-        "properties": {
-          "shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "from": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "to": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "sync": {
-            "description": "If `true` transfer is a synchronization of a replicas If `false` transfer is a moving of a shard from one peer to another",
-            "type": "boolean"
-          },
-          "method": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardTransferMethod"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "ShardTransferMethod": {
-        "description": "Methods for transferring a shard from one node to another.",
-        "oneOf": [
-          {
-            "description": "Stream all shard records in batches until the whole shard is transferred.",
-            "type": "string",
-            "enum": ["stream_records"]
-          },
-          {
-            "description": "Snapshot the shard, transfer and restore it on the receiver.",
-            "type": "string",
-            "enum": ["snapshot"]
-          }
-        ]
-      },
-      "TelemetryData": {
-        "type": "object",
-        "required": ["app", "cluster", "collections", "id", "requests"],
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Attempt ID"
           },
-          "app": {
-            "$ref": "#/components/schemas/AppBuildTelemetry"
+          "team_id": {
+            "type": "string",
+            "description": "Team ID"
           },
-          "collections": {
-            "$ref": "#/components/schemas/CollectionsTelemetry"
+          "event_id": {
+            "type": "string",
+            "description": "Event ID"
           },
-          "cluster": {
-            "$ref": "#/components/schemas/ClusterTelemetry"
+          "response_status": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Attempt's HTTP response code"
           },
-          "requests": {
-            "$ref": "#/components/schemas/RequestsTelemetry"
+          "attempt_number": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Sequential number of attempts (up to and including this one) made for the associated event"
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/AttemptTrigger"
+          },
+          "error_code": {
+            "$ref": "#/components/schemas/AttemptErrorCodes"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "nullable": true,
+                "description": "Response body from the destination"
+              },
+              {
+                "type": "string",
+                "nullable": true,
+                "description": "Response body from the destination"
+              }
+            ]
+          },
+          "requested_url": {
+            "type": "string",
+            "nullable": true,
+            "description": "URL of the destination where delivery was attempted"
+          },
+          "http_method": {
+            "type": "string",
+            "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+            "nullable": true,
+            "description": "HTTP method used to deliver the attempt"
+          },
+          "bulk_retry_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of associated bulk retry"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AttemptStatus"
+          },
+          "successful_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the attempt was successful"
+          },
+          "delivered_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the attempt was delivered"
+          },
+          "responded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the destination responded to this attempt"
+          },
+          "delivery_latency": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Time elapsed between attempt initiation and final delivery (in ms)"
+          },
+          "response_latency": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Time elapsed between attempt initiation and a response from the destination (in ms)"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the attempt was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the attempt was created"
+          },
+          "state": {
+            "$ref": "#/components/schemas/AttemptState"
+          },
+          "destination_id": {
+            "type": "string",
+            "nullable": true,
+            "x-docs-hide": true
           }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "event_id",
+          "status",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false,
+        "nullable": true
+      },
+      "EventAttemptPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EventAttempt"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ShortEventData": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Request path"
+          },
+          "query": {
+            "type": "string",
+            "nullable": true,
+            "description": "Raw query param string"
+          },
+          "parsed_query": {
+            "anyOf": [
+              {
+                "type": "string",
+                "nullable": true
+              },
+              {
+                "type": "object",
+                "properties": {}
+              }
+            ],
+            "nullable": true,
+            "description": "JSON representation of query params"
+          },
+          "headers": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            ],
+            "nullable": true,
+            "description": "JSON representation of the headers"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "properties": {}
+              },
+              {
+                "type": "array",
+                "items": {}
+              }
+            ],
+            "nullable": true,
+            "description": "JSON or string representation of the body"
+          },
+          "is_large_payload": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Whether the payload is considered large payload and not searchable"
+          }
+        },
+        "required": ["path", "query", "parsed_query", "headers", "body"],
+        "additionalProperties": false,
+        "nullable": true,
+        "description": "Request data"
+      },
+      "Bookmark": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the bookmark"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "webhook_id": {
+            "type": "string",
+            "description": "ID of the associated connection"
+          },
+          "event_data_id": {
+            "type": "string",
+            "description": "ID of the bookmarked event data"
+          },
+          "label": {
+            "type": "string",
+            "description": "Descriptive name of the bookmark"
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true,
+            "description": "Alternate alias for the bookmark"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ShortEventData"
+          },
+          "last_used_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the bookmark was last manually triggered"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the bookmark was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the bookmark was created"
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "webhook_id",
+          "event_data_id",
+          "label",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false
+      },
+      "BookmarkPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Bookmark"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "RawBody": {
+        "type": "object",
+        "properties": {
+          "body": {
+            "type": "string"
+          }
+        },
+        "required": ["body"],
+        "additionalProperties": false
+      },
+      "EventStatus": {
+        "type": "string",
+        "enum": ["SCHEDULED", "QUEUED", "HOLD", "SUCCESSFUL", "FAILED"]
+      },
+      "Event": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the event"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "webhook_id": {
+            "type": "string",
+            "description": "ID of the associated connection"
+          },
+          "source_id": {
+            "type": "string",
+            "description": "ID of the associated source"
+          },
+          "destination_id": {
+            "type": "string",
+            "description": "ID of the associated destination"
+          },
+          "event_data_id": {
+            "type": "string",
+            "description": "ID of the event data"
+          },
+          "request_id": {
+            "type": "string",
+            "description": "ID of the request that created the event"
+          },
+          "attempts": {
+            "type": "integer",
+            "description": "Number of delivery attempts made"
+          },
+          "last_attempt_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date of the most recently attempted retry"
+          },
+          "next_attempt_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date of the next scheduled retry"
+          },
+          "response_status": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Event status"
+          },
+          "error_code": {
+            "$ref": "#/components/schemas/AttemptErrorCodes"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EventStatus"
+          },
+          "successful_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date of the latest successful attempt"
+          },
+          "cli_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the CLI the event is sent to"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the event was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the event was created"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ShortEventData"
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "webhook_id",
+          "source_id",
+          "destination_id",
+          "event_data_id",
+          "request_id",
+          "attempts",
+          "last_attempt_at",
+          "next_attempt_at",
+          "status",
+          "successful_at",
+          "cli_id",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false
+      },
+      "EventArray": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Event"
         }
       },
-      "AppBuildTelemetry": {
+      "DeletedBookmarkResponse": {
         "type": "object",
-        "required": ["name", "startup", "version"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Bookmark ID"
+          }
+        },
+        "required": ["id"],
+        "additionalProperties": false
+      },
+      "DestinationRateLimitPeriod": {
+        "type": "string",
+        "enum": ["second", "minute", "hour", "concurrent"],
+        "nullable": true,
+        "description": "Period to rate limit attempts",
+        "default": "second"
+      },
+      "DestinationHTTPMethod": {
+        "type": "string",
+        "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+        "nullable": true,
+        "description": "HTTP method used on requests sent to the destination, overrides the method used on requests sent to the source."
+      },
+      "DestinationAuthMethodSignatureConfig": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "Empty config for the destination's auth method"
+      },
+      "AuthHookdeckSignature": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["HOOKDECK_SIGNATURE"],
+            "description": "Type of auth method"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DestinationAuthMethodSignatureConfig"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "description": "Hookdeck Signature",
+        "x-docs-type": "Hookdeck Signature"
+      },
+      "DestinationAuthMethodBasicAuthConfig": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "description": "Username for basic auth"
+          },
+          "password": {
+            "type": "string",
+            "description": "Password for basic auth"
+          }
+        },
+        "required": ["username", "password"],
+        "additionalProperties": false,
+        "description": "Basic auth config for the destination's auth method"
+      },
+      "AuthBasicAuth": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["BASIC_AUTH"],
+            "description": "Type of auth method"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DestinationAuthMethodBasicAuthConfig"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "description": "Basic Auth",
+        "x-docs-type": "Basic Auth"
+      },
+      "DestinationAuthMethodApiKeyConfig": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Key for the API key auth"
+          },
+          "api_key": {
+            "type": "string",
+            "description": "API key for the API key auth"
+          },
+          "to": {
+            "type": "string",
+            "enum": ["header", "query"],
+            "description": "Whether the API key should be sent as a header or a query parameter",
+            "default": "header"
+          }
+        },
+        "required": ["key", "api_key"],
+        "additionalProperties": false,
+        "description": "API key config for the destination's auth method"
+      },
+      "AuthAPIKey": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["API_KEY"],
+            "description": "Type of auth method"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DestinationAuthMethodApiKeyConfig"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "description": "API Key",
+        "x-docs-type": "API Key"
+      },
+      "DestinationAuthMethodBearerTokenConfig": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Token for the bearer token auth"
+          }
+        },
+        "required": ["token"],
+        "additionalProperties": false,
+        "description": "Bearer token config for the destination's auth method"
+      },
+      "AuthBearerToken": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["BEARER_TOKEN"],
+            "description": "Type of auth method"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DestinationAuthMethodBearerTokenConfig"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "description": "Bearer Token",
+        "x-docs-type": "Bearer Token"
+      },
+      "DestinationAuthMethodOAuth2ClientCredentialsConfig": {
+        "type": "object",
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "description": "Client id in the auth server"
+          },
+          "client_secret": {
+            "type": "string",
+            "description": "Client secret in the auth server"
+          },
+          "scope": {
+            "type": "string",
+            "nullable": true,
+            "description": "Scope to access"
+          },
+          "auth_server": {
+            "type": "string",
+            "description": "URL of the auth server",
+            "format": "URL"
+          }
+        },
+        "required": ["client_id", "client_secret", "auth_server"],
+        "additionalProperties": false,
+        "description": "OAuth2 Client Credentials config for the destination's auth method"
+      },
+      "AuthOAuth2ClientCredentials": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["OAUTH2_CLIENT_CREDENTIALS"],
+            "description": "Type of auth method"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DestinationAuthMethodOAuth2ClientCredentialsConfig"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "description": "OAuth2 Client Credentials",
+        "x-docs-type": "OAuth2 Client Credentials"
+      },
+      "DestinationAuthMethodOAuth2AuthorizationCodeConfig": {
+        "type": "object",
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "description": "Client id in the auth server"
+          },
+          "client_secret": {
+            "type": "string",
+            "description": "Client secret in the auth server"
+          },
+          "refresh_token": {
+            "type": "string",
+            "description": "Refresh token already returned by the auth server"
+          },
+          "scope": {
+            "type": "string",
+            "nullable": true,
+            "description": "Scope to access"
+          },
+          "auth_server": {
+            "type": "string",
+            "description": "URL of the auth server",
+            "format": "URL"
+          }
+        },
+        "required": [
+          "client_id",
+          "client_secret",
+          "refresh_token",
+          "auth_server"
+        ],
+        "additionalProperties": false,
+        "description": "OAuth2 Authorization Code config for the destination's auth method"
+      },
+      "AuthOAuth2AuthorizationCode": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["OAUTH2_AUTHORIZATION_CODE"],
+            "description": "Type of auth method"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DestinationAuthMethodOAuth2AuthorizationCodeConfig"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "description": "OAuth2 Authorization Code",
+        "x-docs-type": "OAuth2 Authorization Code"
+      },
+      "DestinationAuthMethodCustomSignatureConfig": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Key for the custom signature auth"
+          },
+          "signing_secret": {
+            "type": "string",
+            "description": "Signing secret for the custom signature auth. If left empty a secret will be generated for you."
+          }
+        },
+        "required": ["key"],
+        "additionalProperties": false,
+        "description": "Custom signature config for the destination's auth method"
+      },
+      "AuthCustomSignature": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["CUSTOM_SIGNATURE"],
+            "description": "Type of auth method"
+          },
+          "config": {
+            "$ref": "#/components/schemas/DestinationAuthMethodCustomSignatureConfig"
+          }
+        },
+        "required": ["type", "config"],
+        "additionalProperties": false,
+        "description": "Custom Signature",
+        "x-docs-type": "Custom Signature"
+      },
+      "DestinationAuthMethodConfig": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/AuthHookdeckSignature"
+          },
+          {
+            "$ref": "#/components/schemas/AuthBasicAuth"
+          },
+          {
+            "$ref": "#/components/schemas/AuthAPIKey",
+            "x-required": true
+          },
+          {
+            "$ref": "#/components/schemas/AuthBearerToken",
+            "x-required": true
+          },
+          {
+            "$ref": "#/components/schemas/AuthOAuth2ClientCredentials",
+            "x-required": true
+          },
+          {
+            "$ref": "#/components/schemas/AuthOAuth2AuthorizationCode",
+            "x-required": true
+          },
+          {
+            "$ref": "#/components/schemas/AuthCustomSignature"
+          }
+        ],
+        "description": "Config for the destination's auth method"
+      },
+      "Destination": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the destination"
+          },
+          "name": {
+            "type": "string",
+            "description": "A unique, human-friendly name for the destination"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "Description of the destination"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "path_forwarding_disabled": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true,
+            "description": "HTTP endpoint of the destination",
+            "format": "URL"
+          },
+          "cli_path": {
+            "type": "string",
+            "nullable": true,
+            "description": "Path for the CLI destination"
+          },
+          "rate_limit": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Limit event attempts to receive per period. Max value is workspace plan's max attempts thoughput."
+          },
+          "rate_limit_period": {
+            "$ref": "#/components/schemas/DestinationRateLimitPeriod"
+          },
+          "http_method": {
+            "$ref": "#/components/schemas/DestinationHTTPMethod"
+          },
+          "auth_method": {
+            "$ref": "#/components/schemas/DestinationAuthMethodConfig"
+          },
+          "archived_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the destination was archived"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the destination was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the destination was created"
+          }
+        },
+        "required": ["id", "name", "team_id", "updated_at", "created_at"],
+        "additionalProperties": false,
+        "description": "Associated [Destination](#destination-object) object"
+      },
+      "DestinationPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Destination"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "BatchOperation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the bulk retry"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": {
+                  "nullable": true
+                }
+              },
+              {
+                "type": "string",
+                "nullable": true
+              }
+            ],
+            "nullable": true,
+            "description": "Query object to filter records",
+            "x-docs-force-simple-type": true,
+            "x-docs-type": "JSON"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the bulk retry was created"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last time the bulk retry was updated"
+          },
+          "cancelled_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the bulk retry was cancelled"
+          },
+          "completed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the bulk retry was completed"
+          },
+          "estimated_batch": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Number of batches required to complete the bulk retry"
+          },
+          "estimated_count": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Number of estimated events to be retried"
+          },
+          "processed_batch": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Number of batches currently processed"
+          },
+          "completed_count": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Number of events that were successfully delivered"
+          },
+          "in_progress": {
+            "type": "boolean",
+            "description": "Indicates if the bulk retry is currently in progress"
+          },
+          "progress": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "description": "Progression of the batch operations, values 0 - 1"
+          },
+          "failed_count": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Number of events that failed to be delivered"
+          },
+          "number": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "x-docs-hide": true
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "created_at",
+          "updated_at",
+          "in_progress"
+        ],
+        "additionalProperties": false
+      },
+      "BatchOperationPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BatchOperation"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "EventPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "RetriedEvent": {
+        "type": "object",
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/Event"
+          },
+          "attempt": {
+            "$ref": "#/components/schemas/EventAttempt"
+          }
+        },
+        "required": ["event", "attempt"],
+        "additionalProperties": false
+      },
+      "IntegrationProvider": {
+        "type": "string",
+        "enum": [
+          "hmac",
+          "basic_auth",
+          "api_key",
+          "cloudsignal",
+          "courier",
+          "twitter",
+          "stripe",
+          "recharge",
+          "twilio",
+          "github",
+          "shopify",
+          "postmark",
+          "typeform",
+          "xero",
+          "svix",
+          "zoom",
+          "akeneo",
+          "adyen",
+          "gitlab",
+          "property-finder",
+          "woocommerce",
+          "oura",
+          "commercelayer",
+          "hubspot",
+          "mailgun",
+          "persona",
+          "pipedrive",
+          "sendgrid",
+          "workos",
+          "synctera",
+          "aws_sns",
+          "three_d_eye",
+          "twitch",
+          "favro",
+          "wix",
+          "nmi",
+          "repay",
+          "square",
+          "solidgate",
+          "trello",
+          "sanity"
+        ]
+      },
+      "IntegrationFeature": {
+        "type": "string",
+        "enum": ["VERIFICATION", "HANDSHAKE", "POLLING"]
+      },
+      "HMACAlgorithms": {
+        "type": "string",
+        "enum": ["md5", "sha1", "sha256", "sha512"]
+      },
+      "HMACIntegrationConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "algorithm": {
+            "$ref": "#/components/schemas/HMACAlgorithms"
+          },
+          "header_key": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string",
+            "enum": ["base64", "hex"]
+          }
+        },
+        "required": [
+          "webhook_secret_key",
+          "algorithm",
+          "header_key",
+          "encoding"
+        ],
+        "additionalProperties": false
+      },
+      "APIKeyIntegrationConfigs": {
+        "type": "object",
+        "properties": {
+          "header_key": {
+            "type": "string"
+          },
+          "api_key": {
+            "type": "string"
+          }
+        },
+        "required": ["header_key", "api_key"],
+        "additionalProperties": false
+      },
+      "HandledAPIKeyIntegrationConfigs": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "type": "string"
+          }
+        },
+        "required": ["api_key"],
+        "additionalProperties": false
+      },
+      "HandledHMACConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false
+      },
+      "BasicAuthIntegrationConfigs": {
+        "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "version": {
+          "password": {
             "type": "string"
+          }
+        },
+        "required": ["name", "password"],
+        "additionalProperties": false
+      },
+      "ShopifyIntegrationConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "rate_limit_period": {
+            "type": "string",
+            "enum": ["minute", "second"],
+            "nullable": true
+          },
+          "rate_limit": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "api_key": {
+            "type": "string",
+            "nullable": true
+          },
+          "api_secret": {
+            "type": "string",
+            "nullable": true
+          },
+          "shop": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false
+      },
+      "Integration": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the integration"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "label": {
+            "type": "string",
+            "description": "Label of the integration"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/IntegrationProvider"
           },
           "features": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntegrationFeature"
+            },
+            "description": "List of features to enable (see features list below)",
+            "x-docs-force-simple-type": true,
+            "x-docs-type": "Array of string"
+          },
+          "configs": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/AppFeaturesTelemetry"
+                "$ref": "#/components/schemas/HMACIntegrationConfigs"
               },
               {
-                "nullable": true
-              }
-            ]
-          },
-          "system": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RunningEnvironmentTelemetry"
+                "$ref": "#/components/schemas/APIKeyIntegrationConfigs"
               },
               {
-                "nullable": true
+                "$ref": "#/components/schemas/HandledAPIKeyIntegrationConfigs"
+              },
+              {
+                "$ref": "#/components/schemas/HandledHMACConfigs"
+              },
+              {
+                "$ref": "#/components/schemas/BasicAuthIntegrationConfigs"
+              },
+              {
+                "$ref": "#/components/schemas/ShopifyIntegrationConfigs"
+              },
+              {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
               }
-            ]
+            ],
+            "description": "Decrypted Key/Value object of the associated configuration for that provider",
+            "x-docs-force-simple-type": true,
+            "x-docs-type": "object"
           },
-          "startup": {
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "ID of the source"
+            },
+            "description": "List of source IDs the integration is attached to"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the integration was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the integration was created"
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "label",
+          "provider",
+          "features",
+          "configs",
+          "sources",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false
+      },
+      "IntegrationPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Integration"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "AttachedIntegrationToSource": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": ["success"],
+        "additionalProperties": false
+      },
+      "DetachedIntegrationFromSource": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "DeletedIntegration": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": ["id"],
+        "additionalProperties": false
+      },
+      "IssueStatus": {
+        "type": "string",
+        "enum": ["OPENED", "IGNORED", "ACKNOWLEDGED", "RESOLVED"],
+        "description": "Issue status"
+      },
+      "DeliveryIssueAggregationKeys": {
+        "type": "object",
+        "properties": {
+          "webhook_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "response_status": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "error_code": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AttemptErrorCodes"
+            }
+          }
+        },
+        "required": ["webhook_id", "response_status", "error_code"],
+        "additionalProperties": false,
+        "description": "Keys used as the aggregation keys a 'delivery' type issue"
+      },
+      "DeliveryIssueReference": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "string"
+          },
+          "attempt_id": {
+            "type": "string"
+          }
+        },
+        "required": ["event_id", "attempt_id"],
+        "additionalProperties": false,
+        "description": "Reference to the event and attempt an issue is being created for."
+      },
+      "DeliveryIssueData": {
+        "type": "object",
+        "properties": {
+          "trigger_event": {
+            "$ref": "#/components/schemas/Event"
+          },
+          "trigger_attempt": {
+            "$ref": "#/components/schemas/EventAttempt"
+          }
+        },
+        "additionalProperties": false,
+        "nullable": true,
+        "description": "Delivery issue data"
+      },
+      "DeliveryIssueWithData": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Issue ID",
+            "example": "iss_YXKv5OdJXCiVwkPhGy"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "status": {
+            "$ref": "#/components/schemas/IssueStatus"
+          },
+          "opened_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue was last opened"
+          },
+          "first_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue was first opened"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue last occured"
+          },
+          "last_updated_by": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the team member who last updated the issue status"
+          },
+          "dismissed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp for when the issue was dismissed"
+          },
+          "auto_resolved_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "merged_with": {
+            "type": "string",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was created"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["delivery"]
+          },
+          "aggregation_keys": {
+            "$ref": "#/components/schemas/DeliveryIssueAggregationKeys"
+          },
+          "reference": {
+            "$ref": "#/components/schemas/DeliveryIssueReference"
+          },
+          "data": {
+            "$ref": "#/components/schemas/DeliveryIssueData"
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "status",
+          "opened_at",
+          "first_seen_at",
+          "last_seen_at",
+          "updated_at",
+          "created_at",
+          "type",
+          "aggregation_keys",
+          "reference"
+        ],
+        "additionalProperties": false,
+        "description": "Delivery issue"
+      },
+      "TransformationIssueAggregationKeys": {
+        "type": "object",
+        "properties": {
+          "transformation_id": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "log_level": {
+            "$ref": "#/components/schemas/TransformationExecutionLogLevel"
+          }
+        },
+        "required": ["transformation_id", "log_level"],
+        "additionalProperties": false,
+        "description": "Keys used as the aggregation keys a 'transformation' type issue"
+      },
+      "TransformationIssueReference": {
+        "type": "object",
+        "properties": {
+          "transformation_execution_id": {
+            "type": "string"
+          },
+          "trigger_event_request_transformation_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "Deprecated but still found on historical issues"
+          }
+        },
+        "required": ["transformation_execution_id"],
+        "additionalProperties": false,
+        "description": "Reference to the event request transformation an issue is being created for."
+      },
+      "ConsoleLine": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["error", "log", "warn", "info", "debug"]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["type", "message"],
+        "additionalProperties": false
+      },
+      "TransformationExecution": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "transformed_event_data_id": {
+            "type": "string"
+          },
+          "original_event_data_id": {
+            "type": "string"
+          },
+          "transformation_id": {
+            "type": "string"
+          },
+          "team_id": {
+            "type": "string"
+          },
+          "webhook_id": {
+            "type": "string"
+          },
+          "log_level": {
+            "$ref": "#/components/schemas/TransformationExecutionLogLevel"
+          },
+          "logs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConsoleLine"
+            }
+          },
+          "updated_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "original_event_data": {
+            "$ref": "#/components/schemas/ShortEventData"
+          },
+          "transformed_event_data": {
+            "$ref": "#/components/schemas/ShortEventData"
+          },
+          "issue_id": {
+            "type": "string",
+            "nullable": true
           }
-        }
-      },
-      "AppFeaturesTelemetry": {
-        "type": "object",
+        },
         "required": [
-          "debug",
-          "recovery_mode",
-          "service_debug_feature",
-          "web_feature"
+          "id",
+          "transformed_event_data_id",
+          "original_event_data_id",
+          "transformation_id",
+          "team_id",
+          "webhook_id",
+          "log_level",
+          "logs",
+          "updated_at",
+          "created_at"
         ],
-        "properties": {
-          "debug": {
-            "type": "boolean"
-          },
-          "web_feature": {
-            "type": "boolean"
-          },
-          "service_debug_feature": {
-            "type": "boolean"
-          },
-          "recovery_mode": {
-            "type": "boolean"
-          }
-        }
+        "additionalProperties": false
       },
-      "RunningEnvironmentTelemetry": {
+      "TransformationIssueData": {
         "type": "object",
-        "required": ["cpu_flags", "is_docker"],
         "properties": {
-          "distribution": {
-            "type": "string",
-            "nullable": true
+          "transformation_execution": {
+            "$ref": "#/components/schemas/TransformationExecution"
           },
-          "distribution_version": {
-            "type": "string",
-            "nullable": true
-          },
-          "is_docker": {
-            "type": "boolean"
-          },
-          "cores": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "ram_size": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "disk_size": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "cpu_flags": {
-            "type": "string"
+          "trigger_attempt": {
+            "$ref": "#/components/schemas/EventAttempt"
           }
-        }
+        },
+        "required": ["transformation_execution"],
+        "additionalProperties": false,
+        "nullable": true,
+        "description": "Transformation issue data"
       },
-      "CollectionsTelemetry": {
+      "TransformationIssueWithData": {
         "type": "object",
-        "required": ["number_of_collections"],
         "properties": {
-          "number_of_collections": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+          "id": {
+            "type": "string",
+            "description": "Issue ID",
+            "example": "iss_YXKv5OdJXCiVwkPhGy"
           },
-          "collections": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CollectionTelemetryEnum"
-            },
-            "nullable": true
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "status": {
+            "$ref": "#/components/schemas/IssueStatus"
+          },
+          "opened_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue was last opened"
+          },
+          "first_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue was first opened"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue last occured"
+          },
+          "last_updated_by": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the team member who last updated the issue status"
+          },
+          "dismissed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp for when the issue was dismissed"
+          },
+          "auto_resolved_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "merged_with": {
+            "type": "string",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was created"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["transformation"]
+          },
+          "aggregation_keys": {
+            "$ref": "#/components/schemas/TransformationIssueAggregationKeys"
+          },
+          "reference": {
+            "$ref": "#/components/schemas/TransformationIssueReference"
+          },
+          "data": {
+            "$ref": "#/components/schemas/TransformationIssueData"
           }
-        }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "status",
+          "opened_at",
+          "first_seen_at",
+          "last_seen_at",
+          "updated_at",
+          "created_at",
+          "type",
+          "aggregation_keys",
+          "reference"
+        ],
+        "additionalProperties": false,
+        "description": "Transformation issue"
       },
-      "CollectionTelemetryEnum": {
+      "IssueWithData": {
         "anyOf": [
           {
-            "$ref": "#/components/schemas/CollectionTelemetry"
+            "$ref": "#/components/schemas/DeliveryIssueWithData"
           },
           {
-            "$ref": "#/components/schemas/CollectionsAggregatedTelemetry"
+            "$ref": "#/components/schemas/TransformationIssueWithData"
           }
         ]
       },
-      "CollectionTelemetry": {
+      "IssueWithDataPaginatedResult": {
         "type": "object",
-        "required": ["config", "id", "init_time_ms", "shards", "transfers"],
         "properties": {
-          "id": {
-            "type": "string"
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
           },
-          "init_time_ms": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
+          "count": {
+            "type": "integer"
           },
-          "config": {
-            "$ref": "#/components/schemas/CollectionConfig"
-          },
-          "shards": {
+          "models": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ReplicaSetTelemetry"
-            }
-          },
-          "transfers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ShardTransferInfo"
+              "$ref": "#/components/schemas/IssueWithData"
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
-      "ReplicaSetTelemetry": {
+      "IssueCount": {
         "type": "object",
-        "required": ["id", "remote", "replicate_states"],
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "local": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/LocalShardTelemetry"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "remote": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RemoteShardTelemetry"
-            }
-          },
-          "replicate_states": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ReplicaState"
-            }
-          }
-        }
-      },
-      "LocalShardTelemetry": {
-        "type": "object",
-        "required": ["optimizations", "segments"],
-        "properties": {
-          "variant_name": {
-            "type": "string",
-            "nullable": true
-          },
-          "segments": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SegmentTelemetry"
-            }
-          },
-          "optimizations": {
-            "$ref": "#/components/schemas/OptimizerTelemetry"
-          }
-        }
-      },
-      "SegmentTelemetry": {
-        "type": "object",
-        "required": [
-          "config",
-          "info",
-          "payload_field_indices",
-          "vector_index_searches"
-        ],
-        "properties": {
-          "info": {
-            "$ref": "#/components/schemas/SegmentInfo"
-          },
-          "config": {
-            "$ref": "#/components/schemas/SegmentConfig"
-          },
-          "vector_index_searches": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VectorIndexSearchesTelemetry"
-            }
-          },
-          "payload_field_indices": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PayloadIndexTelemetry"
-            }
-          }
-        }
-      },
-      "SegmentInfo": {
-        "description": "Aggregated information about segment",
-        "type": "object",
-        "required": [
-          "disk_usage_bytes",
-          "index_schema",
-          "is_appendable",
-          "num_deleted_vectors",
-          "num_indexed_vectors",
-          "num_points",
-          "num_vectors",
-          "ram_usage_bytes",
-          "segment_type",
-          "vector_data"
-        ],
-        "properties": {
-          "segment_type": {
-            "$ref": "#/components/schemas/SegmentType"
-          },
-          "num_vectors": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "num_points": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "num_indexed_vectors": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "num_deleted_vectors": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "ram_usage_bytes": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "disk_usage_bytes": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "is_appendable": {
-            "type": "boolean"
-          },
-          "index_schema": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/PayloadIndexInfo"
-            }
-          },
-          "vector_data": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/VectorDataInfo"
-            }
-          }
-        }
-      },
-      "SegmentType": {
-        "description": "Type of segment",
-        "type": "string",
-        "enum": ["plain", "indexed", "special"]
-      },
-      "VectorDataInfo": {
-        "type": "object",
-        "required": [
-          "num_deleted_vectors",
-          "num_indexed_vectors",
-          "num_vectors"
-        ],
-        "properties": {
-          "num_vectors": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "num_indexed_vectors": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "num_deleted_vectors": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          }
-        }
-      },
-      "SegmentConfig": {
-        "type": "object",
-        "required": ["payload_storage_type"],
-        "properties": {
-          "vector_data": {
-            "default": {},
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/VectorDataConfig"
-            }
-          },
-          "sparse_vector_data": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/SparseVectorDataConfig"
-            }
-          },
-          "payload_storage_type": {
-            "$ref": "#/components/schemas/PayloadStorageType"
-          }
-        }
-      },
-      "VectorDataConfig": {
-        "description": "Config of single vector data storage",
-        "type": "object",
-        "required": ["distance", "index", "size", "storage_type"],
-        "properties": {
-          "size": {
-            "description": "Size/dimensionality of the vectors used",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "distance": {
-            "$ref": "#/components/schemas/Distance"
-          },
-          "storage_type": {
-            "$ref": "#/components/schemas/VectorStorageType"
-          },
-          "index": {
-            "$ref": "#/components/schemas/Indexes"
-          },
-          "quantization_config": {
-            "description": "Vector specific quantization config that overrides collection config",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/QuantizationConfig"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "VectorStorageType": {
-        "description": "Storage types for vectors",
-        "oneOf": [
-          {
-            "description": "Storage in memory (RAM)\n\nWill be very fast at the cost of consuming a lot of memory.",
-            "type": "string",
-            "enum": ["Memory"]
-          },
-          {
-            "description": "Storage in mmap file, not appendable\n\nSearch performance is defined by disk speed and the fraction of vectors that fit in memory.",
-            "type": "string",
-            "enum": ["Mmap"]
-          },
-          {
-            "description": "Storage in chunked mmap files, appendable\n\nSearch performance is defined by disk speed and the fraction of vectors that fit in memory.",
-            "type": "string",
-            "enum": ["ChunkedMmap"]
-          }
-        ]
-      },
-      "Indexes": {
-        "description": "Vector index configuration",
-        "oneOf": [
-          {
-            "description": "Do not use any index, scan whole vector collection during search. Guarantee 100% precision, but may be time consuming on large collections.",
-            "type": "object",
-            "required": ["options", "type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["plain"]
-              },
-              "options": {
-                "type": "object"
-              }
-            }
-          },
-          {
-            "description": "Use filterable HNSW index for approximate search. Is very fast even on a very huge collections, but require additional space to store index and additional time to build it.",
-            "type": "object",
-            "required": ["options", "type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["hnsw"]
-              },
-              "options": {
-                "$ref": "#/components/schemas/HnswConfig"
-              }
-            }
-          }
-        ]
-      },
-      "SparseVectorDataConfig": {
-        "description": "Config of single sparse vector data storage",
-        "type": "object",
-        "required": ["index"],
-        "properties": {
-          "index": {
-            "$ref": "#/components/schemas/SparseIndexConfig"
-          }
-        }
-      },
-      "SparseIndexConfig": {
-        "description": "Configuration for sparse inverted index.",
-        "type": "object",
-        "required": ["index_type"],
-        "properties": {
-          "full_scan_threshold": {
-            "description": "We prefer a full scan search upto (excluding) this number of vectors.\n\nNote: this is number of vectors, not KiloBytes.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "index_type": {
-            "$ref": "#/components/schemas/SparseIndexType"
-          }
-        }
-      },
-      "SparseIndexType": {
-        "description": "Sparse index types",
-        "oneOf": [
-          {
-            "description": "Mutable RAM sparse index",
-            "type": "string",
-            "enum": ["MutableRam"]
-          },
-          {
-            "description": "Immutable RAM sparse index",
-            "type": "string",
-            "enum": ["ImmutableRam"]
-          },
-          {
-            "description": "Mmap sparse index",
-            "type": "string",
-            "enum": ["Mmap"]
-          }
-        ]
-      },
-      "PayloadStorageType": {
-        "description": "Type of payload storage",
-        "oneOf": [
-          {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["in_memory"]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["on_disk"]
-              }
-            }
-          }
-        ]
-      },
-      "VectorIndexSearchesTelemetry": {
-        "type": "object",
-        "required": [
-          "filtered_exact",
-          "filtered_large_cardinality",
-          "filtered_plain",
-          "filtered_small_cardinality",
-          "filtered_sparse",
-          "unfiltered_exact",
-          "unfiltered_hnsw",
-          "unfiltered_plain",
-          "unfiltered_sparse"
-        ],
-        "properties": {
-          "index_name": {
-            "type": "string",
-            "nullable": true
-          },
-          "unfiltered_plain": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "unfiltered_hnsw": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "unfiltered_sparse": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "filtered_plain": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "filtered_small_cardinality": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "filtered_large_cardinality": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "filtered_exact": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "filtered_sparse": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          },
-          "unfiltered_exact": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
-          }
-        }
-      },
-      "OperationDurationStatistics": {
-        "type": "object",
-        "required": ["count"],
         "properties": {
           "count": {
             "type": "integer",
-            "format": "uint",
-            "minimum": 0
+            "description": "Number of issues",
+            "example": 5
+          }
+        },
+        "required": ["count"],
+        "additionalProperties": false
+      },
+      "DeliveryIssue": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Issue ID",
+            "example": "iss_YXKv5OdJXCiVwkPhGy"
           },
-          "fail_count": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
           },
-          "avg_duration_micros": {
-            "type": "number",
-            "format": "float",
-            "nullable": true
+          "status": {
+            "$ref": "#/components/schemas/IssueStatus"
           },
-          "min_duration_micros": {
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          },
-          "max_duration_micros": {
-            "type": "number",
-            "format": "float",
-            "nullable": true
-          },
-          "last_responded": {
+          "opened_at": {
             "type": "string",
             "format": "date-time",
-            "nullable": true
-          }
-        }
-      },
-      "PayloadIndexTelemetry": {
-        "type": "object",
-        "required": ["points_count", "points_values_count"],
-        "properties": {
-          "field_name": {
+            "description": "ISO timestamp for when the issue was last opened"
+          },
+          "first_seen_at": {
             "type": "string",
-            "nullable": true
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue was first opened"
           },
-          "points_values_count": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue last occured"
           },
-          "points_count": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+          "last_updated_by": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the team member who last updated the issue status"
           },
-          "histogram_bucket_size": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
+          "dismissed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp for when the issue was dismissed"
+          },
+          "auto_resolved_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "merged_with": {
+            "type": "string",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was created"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["delivery"]
+          },
+          "aggregation_keys": {
+            "$ref": "#/components/schemas/DeliveryIssueAggregationKeys"
+          },
+          "reference": {
+            "$ref": "#/components/schemas/DeliveryIssueReference"
           }
-        }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "status",
+          "opened_at",
+          "first_seen_at",
+          "last_seen_at",
+          "updated_at",
+          "created_at",
+          "type",
+          "aggregation_keys",
+          "reference"
+        ],
+        "additionalProperties": false,
+        "description": "Delivery issue"
       },
-      "OptimizerTelemetry": {
+      "TransformationIssue": {
         "type": "object",
-        "required": ["log", "optimizations", "status"],
         "properties": {
+          "id": {
+            "type": "string",
+            "description": "Issue ID",
+            "example": "iss_YXKv5OdJXCiVwkPhGy"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
           "status": {
-            "$ref": "#/components/schemas/OptimizersStatus"
+            "$ref": "#/components/schemas/IssueStatus"
           },
-          "optimizations": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
+          "opened_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue was last opened"
           },
-          "log": {
+          "first_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue was first opened"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp for when the issue last occured"
+          },
+          "last_updated_by": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the team member who last updated the issue status"
+          },
+          "dismissed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp for when the issue was dismissed"
+          },
+          "auto_resolved_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "merged_with": {
+            "type": "string",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "updated_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "description": "ISO timestamp for when the issue was created"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["transformation"]
+          },
+          "aggregation_keys": {
+            "$ref": "#/components/schemas/TransformationIssueAggregationKeys"
+          },
+          "reference": {
+            "$ref": "#/components/schemas/TransformationIssueReference"
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "status",
+          "opened_at",
+          "first_seen_at",
+          "last_seen_at",
+          "updated_at",
+          "created_at",
+          "type",
+          "aggregation_keys",
+          "reference"
+        ],
+        "additionalProperties": false,
+        "description": "Transformation issue"
+      },
+      "Issue": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/DeliveryIssue"
+          },
+          {
+            "$ref": "#/components/schemas/TransformationIssue"
+          }
+        ],
+        "description": "Issue"
+      },
+      "RequestRejectionCause": {
+        "type": "string",
+        "enum": [
+          "SOURCE_ARCHIVED",
+          "NO_WEBHOOK",
+          "VERIFICATION_FAILED",
+          "UNSUPPORTED_HTTP_METHOD",
+          "UNSUPPORTED_CONTENT_TYPE",
+          "UNPARSABLE_JSON",
+          "PAYLOAD_TOO_LARGE",
+          "INGESTION_FATAL",
+          "UNKNOWN"
+        ],
+        "x-docs-type": "string"
+      },
+      "Request": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the request"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "verified": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Whether or not the request was verified when received"
+          },
+          "original_event_data_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the request data"
+          },
+          "rejection_cause": {
+            "$ref": "#/components/schemas/RequestRejectionCause"
+          },
+          "ingest_priority": {
+            "type": "string",
+            "enum": ["NORMAL", "LOW"],
+            "nullable": true,
+            "description": "The priority attributed to the request when received"
+          },
+          "ingested_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "The time the request was originally received"
+          },
+          "source_id": {
+            "type": "string",
+            "description": "ID of the associated source"
+          },
+          "events_count": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The count of events created from this request (CLI events not included)"
+          },
+          "cli_events_count": {
+            "type": "integer",
+            "nullable": true,
+            "description": "The count of CLI events created from this request"
+          },
+          "ignored_count": {
+            "type": "integer",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the event was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "\tDate the event was created"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ShortEventData"
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "verified",
+          "original_event_data_id",
+          "rejection_cause",
+          "ingest_priority",
+          "ingested_at",
+          "source_id",
+          "events_count",
+          "cli_events_count",
+          "ignored_count",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false
+      },
+      "RequestPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TrackerTelemetry"
+              "$ref": "#/components/schemas/Request"
             }
           }
-        }
+        },
+        "additionalProperties": false
       },
-      "TrackerTelemetry": {
-        "description": "Tracker object used in telemetry",
+      "RetryRequest": {
         "type": "object",
-        "required": ["name", "segment_ids", "start_at", "status"],
         "properties": {
-          "name": {
-            "description": "Name of the optimizer",
+          "request": {
+            "$ref": "#/components/schemas/Request"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Event"
+            },
+            "nullable": true
+          }
+        },
+        "required": ["request"],
+        "additionalProperties": false
+      },
+      "IgnoredEventCause": {
+        "type": "string",
+        "enum": [
+          "ARCHIVED",
+          "FILTERED",
+          "TRANSFORMATION_FAILED",
+          "CLI_DISCONNECTED"
+        ]
+      },
+      "FilteredMeta": {
+        "type": "string",
+        "enum": ["body", "headers", "path", "query"]
+      },
+      "TransformationFailedMeta": {
+        "type": "object",
+        "properties": {
+          "transformation_id": {
+            "type": "string"
+          }
+        },
+        "required": ["transformation_id"],
+        "additionalProperties": false
+      },
+      "IgnoredEvent": {
+        "type": "object",
+        "properties": {
+          "id": {
             "type": "string"
           },
-          "segment_ids": {
-            "description": "Segment IDs being optimized",
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "uint",
-              "minimum": 0
-            }
+          "team_id": {
+            "type": "string"
           },
-          "status": {
-            "$ref": "#/components/schemas/TrackerStatus"
+          "webhook_id": {
+            "type": "string"
           },
-          "start_at": {
-            "description": "Start time of the optimizer",
+          "cause": {
+            "$ref": "#/components/schemas/IgnoredEventCause"
+          },
+          "request_id": {
+            "type": "string"
+          },
+          "meta": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FilteredMeta"
+              },
+              {
+                "$ref": "#/components/schemas/TransformationFailedMeta"
+              }
+            ],
+            "nullable": true
+          },
+          "updated_at": {
             "type": "string",
             "format": "date-time"
           },
-          "end_at": {
-            "description": "End time of the optimizer",
+          "created_at": {
             "type": "string",
-            "format": "date-time",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "webhook_id",
+          "cause",
+          "request_id",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false
+      },
+      "IgnoredEventPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IgnoredEvent"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "VerificationHMACConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "algorithm": {
+            "$ref": "#/components/schemas/HMACAlgorithms"
+          },
+          "header_key": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string",
+            "enum": ["base64", "base64url", "hex"]
+          }
+        },
+        "required": [
+          "webhook_secret_key",
+          "algorithm",
+          "header_key",
+          "encoding"
+        ],
+        "additionalProperties": false,
+        "description": "The verification configs for HMAC. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "HMACConfigs"
+      },
+      "VerificationHMAC": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["hmac"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationHMACConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "HMAC"
+      },
+      "VerificationBasicAuthConfigs": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "required": ["name", "password"],
+        "additionalProperties": false,
+        "description": "The verification configs for Basic Auth. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "BasicAuthConfigs"
+      },
+      "VerificationBasicAuth": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["basic_auth"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationBasicAuthConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Basic Auth"
+      },
+      "VerificationAPIKeyConfigs": {
+        "type": "object",
+        "properties": {
+          "header_key": {
+            "type": "string"
+          },
+          "api_key": {
+            "type": "string"
+          }
+        },
+        "required": ["header_key", "api_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for API Key. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "APIKeyConfigs"
+      },
+      "VerificationAPIKey": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["api_key"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationAPIKeyConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "API Key"
+      },
+      "VerificationCloudSignalConfigs": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "type": "string"
+          }
+        },
+        "required": ["api_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Cloud Signal. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "CloudSignalConfigs"
+      },
+      "VerificationCloudSignal": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["cloudsignal"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationCloudSignalConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Cloud Signal"
+      },
+      "VerificationCourierConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Courier. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "CourierConfigs"
+      },
+      "VerificationCourier": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["courier"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationCourierConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Courier"
+      },
+      "VerificationTwitterConfigs": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "type": "string"
+          }
+        },
+        "required": ["api_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Twitter. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "TwitterConfigs"
+      },
+      "VerificationTwitter": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["twitter"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationTwitterConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Twitter"
+      },
+      "VerificationStripeConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Stripe. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "StripeConfigs"
+      },
+      "VerificationStripe": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["stripe"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationStripeConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Stripe"
+      },
+      "VerificationRechargeConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "algorithm": {
+            "$ref": "#/components/schemas/HMACAlgorithms"
+          },
+          "header_key": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string",
+            "enum": ["base64", "base64url", "hex"]
+          }
+        },
+        "required": [
+          "webhook_secret_key",
+          "algorithm",
+          "header_key",
+          "encoding"
+        ],
+        "additionalProperties": false,
+        "description": "The verification configs for Recharge. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "RechargeConfigs"
+      },
+      "VerificationRecharge": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["recharge"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationRechargeConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Recharge"
+      },
+      "VerificationTwilioConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "algorithm": {
+            "$ref": "#/components/schemas/HMACAlgorithms"
+          },
+          "header_key": {
+            "type": "string"
+          },
+          "encoding": {
+            "type": "string",
+            "enum": ["base64", "base64url", "hex"]
+          }
+        },
+        "required": [
+          "webhook_secret_key",
+          "algorithm",
+          "header_key",
+          "encoding"
+        ],
+        "additionalProperties": false,
+        "description": "The verification configs for Twilio. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "TwilioConfigs"
+      },
+      "VerificationTwilio": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["twilio"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationTwilioConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Twilio"
+      },
+      "VerificationGitHubConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for GitHub. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "GitHubConfigs"
+      },
+      "VerificationGitHub": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["github"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationGitHubConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "GitHub"
+      },
+      "VerificationShopifyConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "rate_limit_period": {
+            "type": "string",
+            "enum": ["minute", "second"],
+            "nullable": true
+          },
+          "rate_limit": {
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "api_key": {
+            "type": "string",
+            "nullable": true
+          },
+          "api_secret": {
+            "type": "string",
+            "nullable": true
+          },
+          "shop": {
+            "type": "string",
             "nullable": true
           }
-        }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Shopify. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "ShopifyConfigs"
       },
-      "TrackerStatus": {
-        "description": "Represents the current state of the optimizer being tracked",
+      "VerificationShopify": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["shopify"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationShopifyConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Shopify"
+      },
+      "VerificationPostmarkConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Postmark. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "PostmarkConfigs"
+      },
+      "VerificationPostmark": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["postmark"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationPostmarkConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Postmark"
+      },
+      "VerificationTypeformConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Typeform. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "TypeformConfigs"
+      },
+      "VerificationTypeform": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["typeform"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationTypeformConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Typeform"
+      },
+      "VerificationXeroConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Xero. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "XeroConfigs"
+      },
+      "VerificationXero": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["xero"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationXeroConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Xero"
+      },
+      "VerificationSvixConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Svix. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "SvixConfigs"
+      },
+      "VerificationSvix": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["svix"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationSvixConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Svix"
+      },
+      "VerificationZoomConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Zoom. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "ZoomConfigs"
+      },
+      "VerificationZoom": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["zoom"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationZoomConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Zoom"
+      },
+      "VerificationAkeneoConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Akeneo. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "AkeneoConfigs"
+      },
+      "VerificationAkeneo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["akeneo"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationAkeneoConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Akeneo"
+      },
+      "VerificationAdyenConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Adyen. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "AdyenConfigs"
+      },
+      "VerificationAdyen": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["adyen"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationAdyenConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Adyen"
+      },
+      "VerificationGitLabConfigs": {
+        "type": "object",
+        "properties": {
+          "api_key": {
+            "type": "string"
+          }
+        },
+        "required": ["api_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for GitLab. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "GitLabConfigs"
+      },
+      "VerificationGitLab": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["gitlab"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationGitLabConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "GitLab"
+      },
+      "VerificationPropertyFinderConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Property Finder. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "PropertyFinderConfigs"
+      },
+      "VerificationPropertyFinder": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["property-finder"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationPropertyFinderConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Property Finder"
+      },
+      "VerificationWooCommerceConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for WooCommerce. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "WooCommerceConfigs"
+      },
+      "VerificationWooCommerce": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["woocommerce"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationWooCommerceConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "WooCommerce"
+      },
+      "VerificationOuraConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Oura. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "OuraConfigs"
+      },
+      "VerificationOura": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["oura"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationOuraConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Oura"
+      },
+      "VerificationCommercelayerConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Commercelayer. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "CommercelayerConfigs"
+      },
+      "VerificationCommercelayer": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["commercelayer"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationCommercelayerConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Commercelayer"
+      },
+      "VerificationHubspotConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Hubspot. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "HubspotConfigs"
+      },
+      "VerificationHubspot": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["hubspot"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationHubspotConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Hubspot"
+      },
+      "VerificationMailgunConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Mailgun. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "MailgunConfigs"
+      },
+      "VerificationMailgun": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["mailgun"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationMailgunConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Mailgun"
+      },
+      "VerificationPersonaConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Persona. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "PersonaConfigs"
+      },
+      "VerificationPersona": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["persona"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationPersonaConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Persona"
+      },
+      "VerificationPipedriveConfigs": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        },
+        "required": ["name", "password"],
+        "additionalProperties": false,
+        "description": "The verification configs for Pipedrive. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "PipedriveConfigs"
+      },
+      "VerificationPipedrive": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["pipedrive"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationPipedriveConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Pipedrive"
+      },
+      "VerificationSendGridConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for SendGrid. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "SendGridConfigs"
+      },
+      "VerificationSendGrid": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["sendgrid"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationSendGridConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "SendGrid"
+      },
+      "VerificationWorkOSConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for WorkOS. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "WorkOSConfigs"
+      },
+      "VerificationWorkOS": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["workos"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationWorkOSConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "WorkOS"
+      },
+      "VerificationSyncteraConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Synctera. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "SyncteraConfigs"
+      },
+      "VerificationSynctera": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["synctera"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationSyncteraConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Synctera"
+      },
+      "VerificationAWSSNSConfigs": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+        "description": "The verification configs for AWS SNS. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "AWSSNSConfigs"
+      },
+      "VerificationAWSSNS": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["aws_sns"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationAWSSNSConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "AWS SNS"
+      },
+      "Verification3dEyeConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for 3dEye. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "3dEyeConfigs"
+      },
+      "Verification3dEye": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["three_d_eye"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/Verification3dEyeConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "3dEye"
+      },
+      "VerificationTwitchConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Twitch. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "TwitchConfigs"
+      },
+      "VerificationTwitch": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["twitch"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationTwitchConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Twitch"
+      },
+      "VerificationFavroConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key", "url"],
+        "additionalProperties": false,
+        "description": "The verification configs for Favro. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "FavroConfigs"
+      },
+      "VerificationFavro": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["favro"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationFavroConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Favro"
+      },
+      "VerificationWixConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Wix. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "WixConfigs"
+      },
+      "VerificationWix": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["wix"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationWixConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Wix"
+      },
+      "VerificationNMIPaymentGatewayConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for NMI Payment Gateway. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "NMIPaymentGatewayConfigs"
+      },
+      "VerificationNMIPaymentGateway": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["nmi"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationNMIPaymentGatewayConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "NMI Payment Gateway"
+      },
+      "VerificationRepayConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Repay. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "RepayConfigs"
+      },
+      "VerificationRepay": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["repay"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationRepayConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Repay"
+      },
+      "VerificationSquareConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key", "url"],
+        "additionalProperties": false,
+        "description": "The verification configs for Square. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "SquareConfigs"
+      },
+      "VerificationSquare": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["square"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationSquareConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Square"
+      },
+      "VerificationSolidGateConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for SolidGate. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "SolidGateConfigs"
+      },
+      "VerificationSolidGate": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["solidgate"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationSolidGateConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "SolidGate"
+      },
+      "VerificationTrelloConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key", "url"],
+        "additionalProperties": false,
+        "description": "The verification configs for Trello. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "TrelloConfigs"
+      },
+      "VerificationTrello": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["trello"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationTrelloConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Trello"
+      },
+      "VerificationSanityConfigs": {
+        "type": "object",
+        "properties": {
+          "webhook_secret_key": {
+            "type": "string"
+          }
+        },
+        "required": ["webhook_secret_key"],
+        "additionalProperties": false,
+        "description": "The verification configs for Sanity. Only included if the ?include=verification.configs query param is present",
+        "x-docs-type": "SanityConfigs"
+      },
+      "VerificationSanity": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["sanity"]
+          },
+          "configs": {
+            "$ref": "#/components/schemas/VerificationSanityConfigs"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false,
+        "x-docs-type": "Sanity"
+      },
+      "VerificationConfig": {
         "oneOf": [
           {
+            "$ref": "#/components/schemas/VerificationHMAC"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationBasicAuth"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationAPIKey"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationCloudSignal"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationCourier"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationTwitter"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationStripe"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationRecharge"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationTwilio"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationGitHub"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationShopify"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationPostmark"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationTypeform"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationXero"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationSvix"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationZoom"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationAkeneo"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationAdyen"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationGitLab"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationPropertyFinder"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationWooCommerce"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationOura"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationCommercelayer"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationHubspot"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationMailgun"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationPersona"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationPipedrive"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationSendGrid"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationWorkOS"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationSynctera"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationAWSSNS"
+          },
+          {
+            "$ref": "#/components/schemas/Verification3dEye"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationTwitch"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationFavro"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationWix"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationNMIPaymentGateway"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationRepay"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationSquare"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationSolidGate"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationTrello"
+          },
+          {
+            "$ref": "#/components/schemas/VerificationSanity"
+          }
+        ],
+        "nullable": true,
+        "description": "The verification configs for the specific verification type"
+      },
+      "SourceAllowedHTTPMethod": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        },
+        "nullable": true,
+        "description": "List of allowed HTTP methods. Defaults to PUT, POST, PATCH, DELETE."
+      },
+      "SourceCustomResponseContentType": {
+        "type": "string",
+        "enum": ["json", "text", "xml"],
+        "description": "Content type of the custom response"
+      },
+      "SourceCustomResponse": {
+        "type": "object",
+        "properties": {
+          "content_type": {
+            "$ref": "#/components/schemas/SourceCustomResponseContentType"
+          },
+          "body": {
             "type": "string",
-            "enum": ["optimizing", "done"]
-          },
-          {
-            "type": "object",
-            "required": ["cancelled"],
-            "properties": {
-              "cancelled": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": ["error"],
-            "properties": {
-              "error": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
+            "maxLength": 1000,
+            "description": "Body of the custom response"
           }
-        ]
+        },
+        "required": ["content_type", "body"],
+        "additionalProperties": false,
+        "nullable": true,
+        "description": "Custom response object"
       },
-      "RemoteShardTelemetry": {
+      "Source": {
         "type": "object",
-        "required": ["searches", "shard_id", "updates"],
         "properties": {
-          "shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
+          "id": {
+            "type": "string",
+            "description": "ID of the source"
           },
-          "peer_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0,
-            "nullable": true
+          "name": {
+            "type": "string",
+            "description": "Name for the source"
           },
-          "searches": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "Description of the source"
           },
-          "updates": {
-            "$ref": "#/components/schemas/OperationDurationStatistics"
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "url": {
+            "type": "string",
+            "description": "A unique URL that must be supplied to your webhook's provider",
+            "format": "URL"
+          },
+          "verification": {
+            "$ref": "#/components/schemas/VerificationConfig"
+          },
+          "allowed_http_methods": {
+            "$ref": "#/components/schemas/SourceAllowedHTTPMethod"
+          },
+          "custom_response": {
+            "$ref": "#/components/schemas/SourceCustomResponse"
+          },
+          "archived_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the source was archived"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the source was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the source was created"
           }
-        }
+        },
+        "required": [
+          "id",
+          "name",
+          "team_id",
+          "url",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false,
+        "description": "Associated [Source](#source-object) object"
       },
-      "CollectionsAggregatedTelemetry": {
+      "SourcePaginatedResult": {
         "type": "object",
-        "required": ["optimizers_status", "params", "vectors"],
         "properties": {
-          "vectors": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
           },
-          "optimizers_status": {
-            "$ref": "#/components/schemas/OptimizersStatus"
+          "count": {
+            "type": "integer"
           },
-          "params": {
-            "$ref": "#/components/schemas/CollectionParams"
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Source"
+            }
           }
-        }
+        },
+        "additionalProperties": false
       },
-      "ClusterTelemetry": {
+      "TopicsValue": {
+        "type": "string",
+        "enum": [
+          "issue.opened",
+          "issue.updated",
+          "deprecated.attempt-failed",
+          "event.successful"
+        ],
+        "description": "Supported topics",
+        "x-docs-type": "string"
+      },
+      "ToggleWebhookNotifications": {
         "type": "object",
-        "required": ["enabled"],
         "properties": {
           "enabled": {
             "type": "boolean"
           },
-          "status": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ClusterStatusTelemetry"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "config": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ClusterConfigTelemetry"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "ClusterStatusTelemetry": {
-        "type": "object",
-        "required": [
-          "commit",
-          "consensus_thread_status",
-          "is_voter",
-          "number_of_peers",
-          "pending_operations",
-          "term"
-        ],
-        "properties": {
-          "number_of_peers": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "term": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "commit": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "pending_operations": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "role": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/StateRole"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "is_voter": {
-            "type": "boolean"
-          },
-          "peer_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0,
-            "nullable": true
-          },
-          "consensus_thread_status": {
-            "$ref": "#/components/schemas/ConsensusThreadStatus"
-          }
-        }
-      },
-      "ClusterConfigTelemetry": {
-        "type": "object",
-        "required": ["consensus", "grpc_timeout_ms", "p2p"],
-        "properties": {
-          "grpc_timeout_ms": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "p2p": {
-            "$ref": "#/components/schemas/P2pConfigTelemetry"
-          },
-          "consensus": {
-            "$ref": "#/components/schemas/ConsensusConfigTelemetry"
-          }
-        }
-      },
-      "P2pConfigTelemetry": {
-        "type": "object",
-        "required": ["connection_pool_size"],
-        "properties": {
-          "connection_pool_size": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          }
-        }
-      },
-      "ConsensusConfigTelemetry": {
-        "type": "object",
-        "required": [
-          "bootstrap_timeout_sec",
-          "max_message_queue_size",
-          "tick_period_ms"
-        ],
-        "properties": {
-          "max_message_queue_size": {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "tick_period_ms": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "bootstrap_timeout_sec": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          }
-        }
-      },
-      "RequestsTelemetry": {
-        "type": "object",
-        "required": ["grpc", "rest"],
-        "properties": {
-          "rest": {
-            "$ref": "#/components/schemas/WebApiTelemetry"
-          },
-          "grpc": {
-            "$ref": "#/components/schemas/GrpcTelemetry"
-          }
-        }
-      },
-      "WebApiTelemetry": {
-        "type": "object",
-        "required": ["responses"],
-        "properties": {
-          "responses": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/OperationDurationStatistics"
-              }
-            }
-          }
-        }
-      },
-      "GrpcTelemetry": {
-        "type": "object",
-        "required": ["responses"],
-        "properties": {
-          "responses": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/OperationDurationStatistics"
-            }
-          }
-        }
-      },
-      "ClusterOperations": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/MoveShardOperation"
-          },
-          {
-            "$ref": "#/components/schemas/ReplicateShardOperation"
-          },
-          {
-            "$ref": "#/components/schemas/AbortTransferOperation"
-          },
-          {
-            "$ref": "#/components/schemas/DropReplicaOperation"
-          },
-          {
-            "$ref": "#/components/schemas/CreateShardingKeyOperation"
-          },
-          {
-            "$ref": "#/components/schemas/DropShardingKeyOperation"
-          }
-        ]
-      },
-      "MoveShardOperation": {
-        "type": "object",
-        "required": ["move_shard"],
-        "properties": {
-          "move_shard": {
-            "$ref": "#/components/schemas/MoveShard"
-          }
-        }
-      },
-      "MoveShard": {
-        "type": "object",
-        "required": ["from_peer_id", "shard_id", "to_peer_id"],
-        "properties": {
-          "shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "to_peer_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "from_peer_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "method": {
-            "description": "Method for transferring the shard from one node to another",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardTransferMethod"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "ReplicateShardOperation": {
-        "type": "object",
-        "required": ["replicate_shard"],
-        "properties": {
-          "replicate_shard": {
-            "$ref": "#/components/schemas/MoveShard"
-          }
-        }
-      },
-      "AbortTransferOperation": {
-        "type": "object",
-        "required": ["abort_transfer"],
-        "properties": {
-          "abort_transfer": {
-            "$ref": "#/components/schemas/MoveShard"
-          }
-        }
-      },
-      "DropReplicaOperation": {
-        "type": "object",
-        "required": ["drop_replica"],
-        "properties": {
-          "drop_replica": {
-            "$ref": "#/components/schemas/Replica"
-          }
-        }
-      },
-      "Replica": {
-        "type": "object",
-        "required": ["peer_id", "shard_id"],
-        "properties": {
-          "shard_id": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "peer_id": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          }
-        }
-      },
-      "CreateShardingKeyOperation": {
-        "type": "object",
-        "required": ["create_sharding_key"],
-        "properties": {
-          "create_sharding_key": {
-            "$ref": "#/components/schemas/CreateShardingKey"
-          }
-        }
-      },
-      "CreateShardingKey": {
-        "type": "object",
-        "required": ["shard_key"],
-        "properties": {
-          "shard_key": {
-            "$ref": "#/components/schemas/ShardKey"
-          },
-          "shards_number": {
-            "description": "How many shards to create for this key If not specified, will use the default value from config",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1,
-            "nullable": true
-          },
-          "replication_factor": {
-            "description": "How many replicas to create for each shard If not specified, will use the default value from config",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1,
-            "nullable": true
-          },
-          "placement": {
-            "description": "Placement of shards for this key List of peer ids, that can be used to place shards for this key If not specified, will be randomly placed among all peers",
+          "topics": {
             "type": "array",
             "items": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0
+              "$ref": "#/components/schemas/TopicsValue"
             },
             "nullable": true
-          }
-        }
-      },
-      "DropShardingKeyOperation": {
-        "type": "object",
-        "required": ["drop_sharding_key"],
-        "properties": {
-          "drop_sharding_key": {
-            "$ref": "#/components/schemas/DropShardingKey"
-          }
-        }
-      },
-      "DropShardingKey": {
-        "type": "object",
-        "required": ["shard_key"],
-        "properties": {
-          "shard_key": {
-            "$ref": "#/components/schemas/ShardKey"
-          }
-        }
-      },
-      "SearchRequestBatch": {
-        "type": "object",
-        "required": ["searches"],
-        "properties": {
-          "searches": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SearchRequest"
-            }
-          }
-        }
-      },
-      "RecommendRequestBatch": {
-        "type": "object",
-        "required": ["searches"],
-        "properties": {
-          "searches": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RecommendRequest"
-            }
-          }
-        }
-      },
-      "LocksOption": {
-        "type": "object",
-        "required": ["write"],
-        "properties": {
-          "error_message": {
-            "type": "string",
-            "nullable": true
           },
-          "write": {
-            "type": "boolean"
-          }
-        }
-      },
-      "SnapshotRecover": {
-        "type": "object",
-        "required": ["location"],
-        "properties": {
-          "location": {
-            "description": "Examples: - URL `http://localhost:8080/collections/my_collection/snapshots/my_snapshot` - Local path `file:///qdrant/snapshots/test_collection-2022-08-04-10-49-10.snapshot`",
-            "type": "string",
-            "format": "uri"
-          },
-          "priority": {
-            "description": "Defines which data should be used as a source of truth if there are other replicas in the cluster. If set to `Snapshot`, the snapshot will be used as a source of truth, and the current state will be overwritten. If set to `Replica`, the current state will be used as a source of truth, and after recovery if will be synchronized with the snapshot.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SnapshotPriority"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "SnapshotPriority": {
-        "description": "Defines source of truth for snapshot recovery: `NoSync` means - restore snapshot without *any* additional synchronization. `Snapshot` means - prefer snapshot data over the current state. `Replica` means - prefer existing data over the snapshot.",
-        "type": "string",
-        "enum": ["no_sync", "snapshot", "replica"]
-      },
-      "CollectionsAliasesResponse": {
-        "type": "object",
-        "required": ["aliases"],
-        "properties": {
-          "aliases": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AliasDescription"
-            }
-          }
-        }
-      },
-      "AliasDescription": {
-        "type": "object",
-        "required": ["alias_name", "collection_name"],
-        "properties": {
-          "alias_name": {
-            "type": "string"
-          },
-          "collection_name": {
+          "source_id": {
             "type": "string"
           }
-        }
+        },
+        "required": ["enabled", "source_id"],
+        "additionalProperties": false
       },
-      "WriteOrdering": {
-        "description": "Defines write ordering guarantees for collection operations\n\n* `weak` - write operations may be reordered, works faster, default\n\n* `medium` - write operations go through dynamically selected leader, may be inconsistent for a short period of time in case of leader change\n\n* `strong` - Write operations go through the permanent leader, consistent, but may be unavailable if leader is down",
-        "type": "string",
-        "enum": ["weak", "medium", "strong"]
-      },
-      "ReadConsistency": {
-        "description": "Read consistency parameter\n\nDefines how many replicas should be queried to get the result\n\n* `N` - send N random request and return points, which present on all of them\n\n* `majority` - send N/2+1 random request and return points, which present on all of them\n\n* `quorum` - send requests to all nodes and return points which present on majority of them\n\n* `all` - send requests to all nodes and return points which present on all of them\n\nDefault value is `Factor(1)`",
-        "anyOf": [
-          {
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          {
-            "$ref": "#/components/schemas/ReadConsistencyType"
-          }
-        ]
-      },
-      "ReadConsistencyType": {
-        "description": "* `majority` - send N/2+1 random request and return points, which present on all of them\n\n* `quorum` - send requests to all nodes and return points which present on majority of nodes\n\n* `all` - send requests to all nodes and return points which present on all nodes",
-        "type": "string",
-        "enum": ["majority", "quorum", "all"]
-      },
-      "UpdateVectors": {
+      "AddCustomHostname": {
         "type": "object",
-        "required": ["points"],
         "properties": {
-          "points": {
-            "description": "Points with named vectors",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PointVectors"
-            },
-            "minItems": 1
-          },
-          "shard_key": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
+          "hostname": {
+            "type": "string",
+            "description": "The custom hostname to attach to the workspace"
           }
-        }
+        },
+        "required": ["hostname"],
+        "additionalProperties": false
       },
-      "PointVectors": {
+      "DeleteCustomDomainSchema": {
         "type": "object",
-        "required": ["id", "vector"],
         "properties": {
           "id": {
-            "$ref": "#/components/schemas/ExtendedPointId"
-          },
-          "vector": {
-            "$ref": "#/components/schemas/VectorStruct"
+            "type": "string",
+            "description": "The custom hostname ID"
           }
-        }
+        },
+        "required": ["id"],
+        "additionalProperties": false
       },
-      "DeleteVectors": {
-        "type": "object",
-        "required": ["vector"],
-        "properties": {
-          "points": {
-            "description": "Deletes values from each point in this list",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtendedPointId"
-            },
-            "nullable": true
-          },
-          "filter": {
-            "description": "Deletes values from points that satisfy this filter condition",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "vector": {
-            "description": "Vector names",
-            "type": "array",
-            "items": {
+      "ListCustomDomainSchema": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
               "type": "string"
             },
-            "minItems": 1,
-            "uniqueItems": true
-          },
-          "shard_key": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
+            "hostname": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "ssl": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "method": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "txt_name": {
+                  "type": "string"
+                },
+                "txt_value": {
+                  "type": "string"
+                },
+                "validation_records": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "status": {
+                        "type": "string"
+                      },
+                      "txt_name": {
+                        "type": "string"
+                      },
+                      "txt_value": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "dcv_delegation_records": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "cname": {
+                        "type": "string"
+                      },
+                      "cname_target": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "settings": {
+                  "type": "object",
+                  "properties": {
+                    "min_tls_version": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "bundle_method": {
+                  "type": "string"
+                },
+                "wildcard": {
+                  "type": "boolean"
+                },
+                "certificate_authority": {
+                  "type": "string"
+                }
               },
-              {
-                "nullable": true
+              "additionalProperties": false
+            },
+            "verification_errors": {
+              "type": "array",
+              "items": {
+                "type": "string"
               }
-            ]
-          }
-        }
-      },
-      "PointGroup": {
-        "type": "object",
-        "required": ["hits", "id"],
-        "properties": {
-          "hits": {
-            "description": "Scored points that have the same value of the group_by key",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ScoredPoint"
+            },
+            "ownership_verification": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "created_at": {
+              "type": "string"
             }
           },
+          "additionalProperties": false
+        }
+      },
+      "Transformation": {
+        "type": "object",
+        "properties": {
           "id": {
-            "$ref": "#/components/schemas/GroupId"
+            "type": "string",
+            "description": "ID of the transformation"
           },
-          "lookup": {
-            "description": "Record that has been looked up using the group id",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Record"
-              },
-              {
-                "nullable": true
-              }
-            ]
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "name": {
+            "type": "string",
+            "description": "A unique, human-friendly name for the transformation"
+          },
+          "code": {
+            "type": "string",
+            "description": "JavaScript code to be executed"
+          },
+          "encrypted_env": {
+            "type": "string",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "iv": {
+            "type": "string",
+            "nullable": true,
+            "x-docs-hide": true
+          },
+          "env": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true,
+            "description": "Key-value environment variables to be passed to the transformation",
+            "x-docs-force-simple-type": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the transformation was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the transformation was created"
           }
-        }
+        },
+        "required": [
+          "id",
+          "team_id",
+          "name",
+          "code",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false
       },
-      "GroupId": {
-        "description": "Value of the group_by key, shared across all the hits in the group",
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          {
-            "type": "integer",
-            "format": "int64"
-          }
-        ]
-      },
-      "SearchGroupsRequest": {
+      "TransformationPaginatedResult": {
         "type": "object",
-        "required": ["group_by", "group_size", "limit", "vector"],
         "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
           },
-          "vector": {
-            "$ref": "#/components/schemas/NamedVectorStruct"
+          "count": {
+            "type": "integer"
           },
-          "filter": {
-            "description": "Look only for points which satisfies this conditions",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "params": {
-            "description": "Additional search params",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SearchParams"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_payload": {
-            "description": "Select which payload to return with the response. Default: None",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vector": {
-            "description": "Whether to return the point vector with the result?",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "score_threshold": {
-            "description": "Define a minimal score threshold for the result. If defined, less similar results will not be returned. Score of the returned result might be higher or smaller than the threshold depending on the Distance function used. E.g. for cosine similarity only higher scores will be returned.",
-            "type": "number",
-            "format": "float",
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Transformation"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "TransformationExecutorOutput": {
+        "type": "object",
+        "properties": {
+          "request_id": {
+            "type": "string",
             "nullable": true
           },
-          "group_by": {
-            "description": "Payload field to group by, must be a string or number field. If the field contains more than 1 value, all values will be used for grouping. One point can be in multiple groups.",
+          "transformation_id": {
             "type": "string",
-            "minLength": 1
-          },
-          "group_size": {
-            "description": "Maximum amount of points to return per group",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1
-          },
-          "limit": {
-            "description": "Maximum amount of groups to return",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1
-          },
-          "with_lookup": {
-            "description": "Look for points in another collection using the group ids",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithLookupInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "WithLookupInterface": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "$ref": "#/components/schemas/WithLookup"
-          }
-        ]
-      },
-      "WithLookup": {
-        "type": "object",
-        "required": ["collection"],
-        "properties": {
-          "collection": {
-            "description": "Name of the collection to use for points lookup",
-            "type": "string"
-          },
-          "with_payload": {
-            "description": "Options for specifying which payload to include (or not)",
-            "default": true,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vectors": {
-            "description": "Options for specifying which vectors to include (or not)",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "RecommendGroupsRequest": {
-        "type": "object",
-        "required": ["group_by", "group_size", "limit"],
-        "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "positive": {
-            "description": "Look for vectors closest to those",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RecommendExample"
-            }
-          },
-          "negative": {
-            "description": "Try to avoid vectors like this",
-            "default": [],
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/RecommendExample"
-            }
-          },
-          "strategy": {
-            "description": "How to use positive and negative examples to find the results",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RecommendStrategy"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "filter": {
-            "description": "Look only for points which satisfies this conditions",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "params": {
-            "description": "Additional search params",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SearchParams"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_payload": {
-            "description": "Select which payload to return with the response. Default: None",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vector": {
-            "description": "Whether to return the point vector with the result?",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "score_threshold": {
-            "description": "Define a minimal score threshold for the result. If defined, less similar results will not be returned. Score of the returned result might be higher or smaller than the threshold depending on the Distance function used. E.g. for cosine similarity only higher scores will be returned.",
-            "type": "number",
-            "format": "float",
             "nullable": true
           },
-          "using": {
-            "description": "Define which vector to use for recommendation, if not specified - try to use default vector",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UsingVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "lookup_from": {
-            "description": "The location used to lookup vectors. If not specified - use current collection. Note: the other collection should have the same vector size as the current collection",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/LookupLocation"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "group_by": {
-            "description": "Payload field to group by, must be a string or number field. If the field contains more than 1 value, all values will be used for grouping. One point can be in multiple groups.",
+          "execution_id": {
             "type": "string",
-            "minLength": 1
+            "nullable": true
           },
-          "group_size": {
-            "description": "Maximum amount of points to return per group",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1
+          "log_level": {
+            "$ref": "#/components/schemas/TransformationExecutionLogLevel"
           },
-          "limit": {
-            "description": "Maximum amount of groups to return",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 1
-          },
-          "with_lookup": {
-            "description": "Look for points in another collection using the group ids",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithLookupInterface"
+          "request": {
+            "type": "object",
+            "properties": {
+              "headers": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": {
+                      "nullable": true
+                    }
+                  }
+                ],
+                "nullable": true
               },
-              {
+              "path": {
+                "type": "string"
+              },
+              "query": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false,
+                    "nullable": true
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "nullable": true
+              },
+              "parsed_query": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  }
+                ],
+                "nullable": true
+              },
+              "body": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                  }
+                ],
                 "nullable": true
               }
-            ]
-          }
-        }
-      },
-      "GroupsResult": {
-        "type": "object",
-        "required": ["groups"],
-        "properties": {
-          "groups": {
+            },
+            "required": ["path"],
+            "additionalProperties": false,
+            "nullable": true
+          },
+          "console": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PointGroup"
-            }
-          }
-        }
-      },
-      "UpdateOperations": {
-        "type": "object",
-        "required": ["operations"],
-        "properties": {
-          "operations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/UpdateOperation"
-            }
-          }
-        }
-      },
-      "UpdateOperation": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/UpsertOperation"
-          },
-          {
-            "$ref": "#/components/schemas/DeleteOperation"
-          },
-          {
-            "$ref": "#/components/schemas/SetPayloadOperation"
-          },
-          {
-            "$ref": "#/components/schemas/OverwritePayloadOperation"
-          },
-          {
-            "$ref": "#/components/schemas/DeletePayloadOperation"
-          },
-          {
-            "$ref": "#/components/schemas/ClearPayloadOperation"
-          },
-          {
-            "$ref": "#/components/schemas/UpdateVectorsOperation"
-          },
-          {
-            "$ref": "#/components/schemas/DeleteVectorsOperation"
-          }
-        ]
-      },
-      "UpsertOperation": {
-        "type": "object",
-        "required": ["upsert"],
-        "properties": {
-          "upsert": {
-            "$ref": "#/components/schemas/PointInsertOperations"
-          }
-        }
-      },
-      "DeleteOperation": {
-        "type": "object",
-        "required": ["delete"],
-        "properties": {
-          "delete": {
-            "$ref": "#/components/schemas/PointsSelector"
-          }
-        }
-      },
-      "SetPayloadOperation": {
-        "type": "object",
-        "required": ["set_payload"],
-        "properties": {
-          "set_payload": {
-            "$ref": "#/components/schemas/SetPayload"
-          }
-        }
-      },
-      "OverwritePayloadOperation": {
-        "type": "object",
-        "required": ["overwrite_payload"],
-        "properties": {
-          "overwrite_payload": {
-            "$ref": "#/components/schemas/SetPayload"
-          }
-        }
-      },
-      "DeletePayloadOperation": {
-        "type": "object",
-        "required": ["delete_payload"],
-        "properties": {
-          "delete_payload": {
-            "$ref": "#/components/schemas/DeletePayload"
-          }
-        }
-      },
-      "ClearPayloadOperation": {
-        "type": "object",
-        "required": ["clear_payload"],
-        "properties": {
-          "clear_payload": {
-            "$ref": "#/components/schemas/PointsSelector"
-          }
-        }
-      },
-      "UpdateVectorsOperation": {
-        "type": "object",
-        "required": ["update_vectors"],
-        "properties": {
-          "update_vectors": {
-            "$ref": "#/components/schemas/UpdateVectors"
-          }
-        }
-      },
-      "DeleteVectorsOperation": {
-        "type": "object",
-        "required": ["delete_vectors"],
-        "properties": {
-          "delete_vectors": {
-            "$ref": "#/components/schemas/DeleteVectors"
-          }
-        }
-      },
-      "ShardSnapshotRecover": {
-        "type": "object",
-        "required": ["location"],
-        "properties": {
-          "location": {
-            "$ref": "#/components/schemas/ShardSnapshotLocation"
-          },
-          "priority": {
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SnapshotPriority"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          }
-        }
-      },
-      "ShardSnapshotLocation": {
-        "anyOf": [
-          {
-            "type": "string",
-            "format": "uri"
-          },
-          {
-            "type": "string"
-          }
-        ]
-      },
-      "DiscoverRequest": {
-        "description": "Use context and a target to find the most similar points, constrained by the context.",
-        "type": "object",
-        "required": ["limit"],
-        "properties": {
-          "shard_key": {
-            "description": "Specify in which shards to look for the points, if not specified - look in all shards",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ShardKeySelector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "target": {
-            "description": "Look for vectors closest to this.\n\nWhen using the target (with or without context), the integer part of the score represents the rank with respect to the context, while the decimal part of the score relates to the distance to the target.",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/RecommendExample"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "context": {
-            "description": "Pairs of { positive, negative } examples to constrain the search.\n\nWhen using only the context (without a target), a special search - called context search - is performed where pairs of points are used to generate a loss that guides the search towards the zone where most positive examples overlap. This means that the score minimizes the scenario of finding a point closer to a negative than to a positive part of a pair.\n\nSince the score of a context relates to loss, the maximum score a point can get is 0.0, and it becomes normal that many points can have a score of 0.0.\n\nFor discovery search (when including a target), the context part of the score for each pair is calculated +1 if the point is closer to a positive than to a negative part of a pair, and -1 otherwise.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ContextExamplePair"
+              "$ref": "#/components/schemas/ConsoleLine"
             },
             "nullable": true
-          },
-          "filter": {
-            "description": "Look only for points which satisfies this conditions",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Filter"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "params": {
-            "description": "Additional search params",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SearchParams"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "limit": {
-            "description": "Max number of result to return",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1
-          },
-          "offset": {
-            "description": "Offset of the first result to return. May be used to paginate results. Note: large offset values may cause performance issues.",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0,
-            "nullable": true
-          },
-          "with_payload": {
-            "description": "Select which payload to return with the response. Default: None",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithPayloadInterface"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "with_vector": {
-            "description": "Whether to return the point vector with the result?",
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/WithVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "using": {
-            "description": "Define which vector to use for recommendation, if not specified - try to use default vector",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/UsingVector"
-              },
-              {
-                "nullable": true
-              }
-            ]
-          },
-          "lookup_from": {
-            "description": "The location used to lookup vectors. If not specified - use current collection. Note: the other collection should have the same vector size as the current collection",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/LookupLocation"
-              },
-              {
-                "nullable": true
-              }
-            ]
           }
-        }
+        },
+        "required": ["log_level"],
+        "additionalProperties": false
       },
-      "ContextExamplePair": {
+      "TransformationExecutionPaginatedResult": {
         "type": "object",
-        "required": ["negative", "positive"],
         "properties": {
-          "positive": {
-            "$ref": "#/components/schemas/RecommendExample"
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
           },
-          "negative": {
-            "$ref": "#/components/schemas/RecommendExample"
-          }
-        }
-      },
-      "DiscoverRequestBatch": {
-        "type": "object",
-        "required": ["searches"],
-        "properties": {
-          "searches": {
+          "count": {
+            "type": "integer"
+          },
+          "models": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DiscoverRequest"
+              "$ref": "#/components/schemas/TransformationExecution"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "RetryStrategy": {
+        "type": "string",
+        "enum": ["linear", "exponential"],
+        "description": "Algorithm to use when calculating delay between retries"
+      },
+      "RetryRule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["retry"],
+            "description": "A retry rule must be of type `retry`"
+          },
+          "strategy": {
+            "$ref": "#/components/schemas/RetryStrategy"
+          },
+          "interval": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Time in MS between each retry"
+          },
+          "count": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Maximum number of retries to attempt"
+          }
+        },
+        "required": ["type", "strategy"],
+        "additionalProperties": false
+      },
+      "FilterRuleProperty": {
+        "anyOf": [
+          {
+            "type": "string",
+            "nullable": true,
+            "x-fern-type-name": "FilterRulePropertyString"
+          },
+          {
+            "type": "number",
+            "format": "float",
+            "x-fern-type-name": "FilterRulePropertyNumber",
+            "nullable": true
+          },
+          {
+            "type": "boolean",
+            "x-fern-type-name": "FilterRulePropertyBoolean",
+            "nullable": true
+          },
+          {
+            "type": "object",
+            "properties": {},
+            "x-fern-type-name": "FilterRulePropertyJSON",
+            "additionalProperties": true,
+            "nullable": true
+          }
+        ],
+        "nullable": true,
+        "description": "JSON using our filter syntax to filter on request headers",
+        "x-docs-type": "JSON",
+        "x-docs-force-simple-type": true
+      },
+      "FilterRule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["filter"],
+            "description": "A filter rule must be of type `filter`"
+          },
+          "headers": {
+            "$ref": "#/components/schemas/FilterRuleProperty"
+          },
+          "body": {
+            "$ref": "#/components/schemas/FilterRuleProperty"
+          },
+          "query": {
+            "$ref": "#/components/schemas/FilterRuleProperty"
+          },
+          "path": {
+            "$ref": "#/components/schemas/FilterRuleProperty"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false
+      },
+      "TransformReference": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["transform"],
+            "description": "A transformation rule must be of type `transformation`"
+          },
+          "transformation_id": {
+            "type": "string",
+            "description": "ID of the attached transformation object. Optional input, always set once the rule is defined"
+          }
+        },
+        "required": ["type", "transformation_id"],
+        "additionalProperties": false
+      },
+      "TransformFull": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["transform"],
+            "description": "A transformation rule must be of type `transformation`"
+          },
+          "transformation_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the attached transformation object. Optional input, always set once the rule is defined"
+          },
+          "transformation": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The unique name of the transformation"
+              },
+              "code": {
+                "type": "string",
+                "description": "A string representation of your JavaScript (ES6) code to run"
+              },
+              "env": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "nullable": true,
+                "description": "A key-value object of environment variables to encrypt and expose to your transformation code"
+              }
+            },
+            "required": ["name", "code"],
+            "additionalProperties": false,
+            "description": "You can optionally define a new transformation while creating a transform rule"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false
+      },
+      "TransformRule": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/TransformReference"
+          },
+          {
+            "$ref": "#/components/schemas/TransformFull"
+          }
+        ]
+      },
+      "DelayRule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["delay"],
+            "description": "A delay rule must be of type `delay`"
+          },
+          "delay": {
+            "type": "integer",
+            "description": "Delay to introduce in MS"
+          }
+        },
+        "required": ["type", "delay"],
+        "additionalProperties": false
+      },
+      "Rule": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RetryRule"
+          },
+          {
+            "$ref": "#/components/schemas/FilterRule"
+          },
+          {
+            "$ref": "#/components/schemas/TransformRule"
+          },
+          {
+            "$ref": "#/components/schemas/DelayRule"
+          }
+        ]
+      },
+      "Connection": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "ID of the connection"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Unique name of the connection for this source"
+          },
+          "full_name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Full name of the connection concatenated from source, connection and desitnation name"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "Description of the connection"
+          },
+          "team_id": {
+            "type": "string",
+            "description": "ID of the workspace"
+          },
+          "destination": {
+            "$ref": "#/components/schemas/Destination"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Source"
+          },
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Rule"
+            },
+            "nullable": true,
+            "description": "Array of rules configured on the connection"
+          },
+          "archived_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the connection was archived"
+          },
+          "paused_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Date the connection was paused"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the connection was last updated"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date the connection was created"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "full_name",
+          "description",
+          "team_id",
+          "destination",
+          "source",
+          "rules",
+          "archived_at",
+          "paused_at",
+          "updated_at",
+          "created_at"
+        ],
+        "additionalProperties": false
+      },
+      "ConnectionPaginatedResult": {
+        "type": "object",
+        "properties": {
+          "pagination": {
+            "$ref": "#/components/schemas/SeekPagination"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Connection"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.hookdeck.com/2023-07-01",
+      "description": "Production API"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    },
+    {
+      "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Issue Triggers",
+      "description": "Issue Triggers lets you setup rules that trigger issues when certain conditions are met."
+    },
+    {
+      "name": "Attempts",
+      "description": "An attempt is any request that Hookdeck makes on behalf of an event."
+    },
+    {
+      "name": "Bookmarks",
+      "description": "A bookmark lets you conveniently store and replay a specific request."
+    },
+    {
+      "name": "Destinations",
+      "description": "A destination is any endpoint to which your webhooks can be routed."
+    },
+    {
+      "name": "Bulk retry events",
+      "description": ""
+    },
+    {
+      "name": "Events",
+      "description": "An event is any request that Hookdeck receives from a source."
+    },
+    {
+      "name": "Bulk retry ignored events",
+      "description": ""
+    },
+    {
+      "name": "Integrations",
+      "description": "An integration configures platform-specific behaviors, such as signature verification."
+    },
+    {
+      "name": "Issues",
+      "description": "Issues lets you track problems in your workspace and communicate resolution steps with your team."
+    },
+    {
+      "name": "Requests",
+      "description": "A request represent a webhook received by Hookdeck."
+    },
+    {
+      "name": "Bulk retry requests",
+      "description": ""
+    },
+    {
+      "name": "Sources",
+      "description": "A source represents any third party that sends webhooks to Hookdeck."
+    },
+    {
+      "name": "Notifications",
+      "description": "Notifications let your team receive alerts anytime an issue changes."
+    },
+    {
+      "name": "Transformations",
+      "description": "A transformation represents JavaScript code that will be executed on a connection's requests. Transformations are applied to connections using Rules."
+    },
+    {
+      "name": "Connections",
+      "description": "A connection lets you route webhooks from a source to a destination, using a ruleset."
+    }
+  ],
+  "paths": {
+    "/issue-triggers": {
+      "get": {
+        "operationId": "getIssueTriggers",
+        "summary": "Get issue triggers",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "List of issue triggers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTriggerPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "Filter by issue trigger name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/IssueType"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IssueType"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "disabled_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Date when the issue trigger was disabled"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at", "type"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at", "type"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createIssueTrigger",
+        "summary": "Create an issue trigger",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "A single issue trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTrigger"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "$ref": "#/components/schemas/IssueType"
+                  },
+                  "configs": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerDeliveryConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerTransformationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerBackpressureConfigs"
+                      }
+                    ],
+                    "description": "Configuration object for the specific issue type selected"
+                  },
+                  "channels": {
+                    "$ref": "#/components/schemas/IssueTriggerChannels"
+                  },
+                  "name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "nullable": true,
+                    "description": "Optional unique name to use as reference when using the API"
+                  }
+                },
+                "required": ["type", "channels"],
+                "additionalProperties": false
+              }
             }
           }
         }
+      },
+      "put": {
+        "operationId": "upsertIssueTrigger",
+        "summary": "Create or update an issue trigger",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "A single issue trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTrigger"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "upsert",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "$ref": "#/components/schemas/IssueType"
+                  },
+                  "configs": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerDeliveryConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerTransformationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerBackpressureConfigs"
+                      }
+                    ],
+                    "description": "Configuration object for the specific issue type selected"
+                  },
+                  "channels": {
+                    "$ref": "#/components/schemas/IssueTriggerChannels"
+                  },
+                  "name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Required unique name to use as reference when using the API"
+                  }
+                },
+                "required": ["type", "channels", "name"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/issue-triggers/{id}": {
+      "get": {
+        "operationId": "getIssueTrigger",
+        "summary": "Get a single issue trigger",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "A single issue trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTrigger"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue trigger ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "retrieve"
+      },
+      "put": {
+        "operationId": "updateIssueTrigger",
+        "summary": "Update an issue trigger",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "A single issue trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTrigger"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue trigger ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "configs": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerDeliveryConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerTransformationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/IssueTriggerBackpressureConfigs"
+                      }
+                    ],
+                    "description": "Configuration object for the specific issue type selected"
+                  },
+                  "channels": {
+                    "$ref": "#/components/schemas/IssueTriggerChannels"
+                  },
+                  "disabled_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true,
+                    "description": "Date when the issue trigger was disabled"
+                  },
+                  "name": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "nullable": true,
+                    "description": "Optional unique name to use as reference when using the API"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteIssueTrigger",
+        "summary": "Delete an issue trigger",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "An object with deleted issue trigger's id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletedIssueTriggerResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue trigger ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "delete"
+      }
+    },
+    "/issue-triggers/{id}/disable": {
+      "put": {
+        "operationId": "disableIssueTrigger",
+        "summary": "Disable an issue trigger",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "A single issue trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTrigger"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue trigger ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "disable"
+      }
+    },
+    "/issue-triggers/{id}/enable": {
+      "put": {
+        "operationId": "enableIssueTrigger",
+        "summary": "Enable an issue trigger",
+        "description": "",
+        "tags": ["Issue Triggers"],
+        "responses": {
+          "200": {
+            "description": "A single issue trigger",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueTrigger"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue trigger ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issueTrigger",
+        "x-fern-sdk-method-name": "enable"
+      }
+    },
+    "/attempts": {
+      "get": {
+        "operationId": "getAttempts",
+        "summary": "Get attempts",
+        "description": "",
+        "tags": ["Attempts"],
+        "responses": {
+          "200": {
+            "description": "List of attempts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventAttemptPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "event_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Event ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Event ID"
+                  }
+                }
+              ],
+              "description": "Event the attempt is associated with"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "attempt",
+        "x-fern-sdk-method-name": "list"
+      }
+    },
+    "/attempts/{id}": {
+      "get": {
+        "operationId": "getAttempt",
+        "summary": "Get a single attempt",
+        "description": "",
+        "tags": ["Attempts"],
+        "responses": {
+          "200": {
+            "description": "A single attempt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventAttempt"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Attempt ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "attempt",
+        "x-fern-sdk-method-name": "retrieve"
+      }
+    },
+    "/bookmarks": {
+      "get": {
+        "operationId": "getBookmarks",
+        "summary": "Get bookmarks",
+        "description": "",
+        "tags": ["Bookmarks"],
+        "responses": {
+          "200": {
+            "description": "List of bookmarks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BookmarkPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Bookmark ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Bookmark ID"
+                  }
+                }
+              ],
+              "description": "Filter by bookmark IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[A-z0-9-_]+$",
+                  "maxLength": 155,
+                  "description": "Bookmark name"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "Bookmark name"
+                  }
+                }
+              ],
+              "description": "Filter by bookmark name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "webhook_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Connection ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Connection ID"
+                  }
+                }
+              ],
+              "description": "Filter by associated connection ID"
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_data_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Event Data ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Event Data ID"
+                  }
+                }
+              ],
+              "description": "Filter by associated event data ID"
+            }
+          },
+          {
+            "in": "query",
+            "name": "label",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Bookmark label"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Bookmark label"
+                  }
+                }
+              ],
+              "description": "Filter by label"
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_used_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true,
+                  "description": "Last used date"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Last used date"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Last used date"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Last used date"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Last used date"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by last used date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "bookmark",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createBookmark",
+        "summary": "Create a bookmark",
+        "description": "",
+        "tags": ["Bookmarks"],
+        "responses": {
+          "200": {
+            "description": "A single bookmark",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Bookmark"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "bookmark",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "event_data_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "ID of the event data to bookmark"
+                  },
+                  "webhook_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "ID of the associated connection"
+                  },
+                  "label": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Descriptive name of the bookmark"
+                  },
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique, human-friendly name for the bookmark"
+                  }
+                },
+                "required": ["event_data_id", "webhook_id", "label"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bookmarks/{id}": {
+      "get": {
+        "operationId": "getBookmark",
+        "summary": "Get a single bookmark",
+        "description": "",
+        "tags": ["Bookmarks"],
+        "responses": {
+          "200": {
+            "description": "A single bookmark",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Bookmark"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bookmark ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "bookmark",
+        "x-fern-sdk-method-name": "retrieve"
+      },
+      "put": {
+        "operationId": "updateBookmark",
+        "summary": "Update a bookmark",
+        "description": "",
+        "tags": ["Bookmarks"],
+        "responses": {
+          "200": {
+            "description": "A single bookmark",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Bookmark"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bookmark ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "bookmark",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "event_data_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "ID of the event data to bookmark"
+                  },
+                  "webhook_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "ID of the associated connection"
+                  },
+                  "label": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Descriptive name of the bookmark"
+                  },
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique, human-friendly name for the bookmark"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteBookmark",
+        "summary": "Delete a bookmark",
+        "description": "",
+        "tags": ["Bookmarks"],
+        "responses": {
+          "200": {
+            "description": "An object with deleted bookmark's id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletedBookmarkResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bookmark ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "bookmark",
+        "x-fern-sdk-method-name": "delete"
+      }
+    },
+    "/bookmarks/{id}/raw_body": {
+      "get": {
+        "operationId": "getRequestRawBody",
+        "summary": "Get a bookmark raw body data",
+        "description": "",
+        "tags": ["Bookmarks"],
+        "responses": {
+          "200": {
+            "description": "A request raw body data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RawBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bookmark ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "bookmark",
+        "x-fern-sdk-method-name": "retrieveBody"
+      }
+    },
+    "/bookmarks/{id}/trigger": {
+      "post": {
+        "operationId": "triggerBookmark",
+        "summary": "Trigger a bookmark",
+        "description": "",
+        "tags": ["Bookmarks"],
+        "responses": {
+          "200": {
+            "description": "Array of created events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventArray"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bookmark ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "bookmark",
+        "x-fern-sdk-method-name": "trigger",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "target": {
+                    "type": "string",
+                    "enum": ["http", "cli"],
+                    "description": "Bookmark target"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/destinations": {
+      "get": {
+        "operationId": "getDestinations",
+        "summary": "Get destinations",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "List of destinations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by destination IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[A-z0-9-_]+$",
+                  "maxLength": 155
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "gte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "le": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "lte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "The destination name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "schema": {
+              "type": "boolean",
+              "description": "Include archived resources in the response"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Date the destination was archived"
+            }
+          },
+          {
+            "in": "query",
+            "name": "url",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "URL"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "URL"
+                  }
+                }
+              ],
+              "description": "HTTP endpoint of the destination"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cli_path",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Path for the CLI destination"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createDestination",
+        "summary": "Create a destination",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "A single destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "Name for the destination"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the destination"
+                  },
+                  "url": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Endpoint of the destination",
+                    "format": "URL"
+                  },
+                  "cli_path": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Path for the CLI destination"
+                  },
+                  "rate_limit_period": {
+                    "type": "string",
+                    "enum": ["second", "minute", "hour"],
+                    "nullable": true,
+                    "description": "Period to rate limit attempts"
+                  },
+                  "rate_limit": {
+                    "type": "integer",
+                    "oneOf": [
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"seconds\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"minute\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"hour\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"concurrent\""
+                      }
+                    ],
+                    "nullable": true,
+                    "description": "Limit event attempts to receive per period",
+                    "x-docs-type": "integer"
+                  },
+                  "http_method": {
+                    "$ref": "#/components/schemas/DestinationHTTPMethod"
+                  },
+                  "auth_method": {
+                    "$ref": "#/components/schemas/DestinationAuthMethodConfig"
+                  },
+                  "path_forwarding_disabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "upsertDestination",
+        "summary": "Update or create a destination",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "A single destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "upsert",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "Name for the destination"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the destination"
+                  },
+                  "url": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Endpoint of the destination",
+                    "format": "URL"
+                  },
+                  "cli_path": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Path for the CLI destination"
+                  },
+                  "rate_limit_period": {
+                    "type": "string",
+                    "enum": ["second", "minute", "hour"],
+                    "nullable": true,
+                    "description": "Period to rate limit attempts"
+                  },
+                  "rate_limit": {
+                    "type": "integer",
+                    "oneOf": [
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"seconds\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"minute\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"hour\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"concurrent\""
+                      }
+                    ],
+                    "nullable": true,
+                    "description": "Limit event attempts to receive per period",
+                    "x-docs-type": "integer"
+                  },
+                  "http_method": {
+                    "$ref": "#/components/schemas/DestinationHTTPMethod"
+                  },
+                  "auth_method": {
+                    "$ref": "#/components/schemas/DestinationAuthMethodConfig"
+                  },
+                  "path_forwarding_disabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/destinations/{id}": {
+      "get": {
+        "operationId": "getDestination",
+        "summary": "Get a destination",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "A single destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Destination ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "retrieve"
+      },
+      "put": {
+        "operationId": "updateDestination",
+        "summary": "Update a destination",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "A single destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Destination ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "Name for the destination"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the destination"
+                  },
+                  "url": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Endpoint of the destination",
+                    "format": "URL"
+                  },
+                  "cli_path": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "Path for the CLI destination"
+                  },
+                  "rate_limit_period": {
+                    "type": "string",
+                    "enum": ["second", "minute", "hour"],
+                    "nullable": true,
+                    "description": "Period to rate limit attempts"
+                  },
+                  "rate_limit": {
+                    "type": "integer",
+                    "oneOf": [
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"seconds\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"minute\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"hour\""
+                      },
+                      {
+                        "type": "integer",
+                        "description": "When rate limit period is set to \"concurrent\""
+                      }
+                    ],
+                    "nullable": true,
+                    "description": "Limit event attempts to receive per period",
+                    "x-docs-type": "integer"
+                  },
+                  "http_method": {
+                    "$ref": "#/components/schemas/DestinationHTTPMethod"
+                  },
+                  "auth_method": {
+                    "$ref": "#/components/schemas/DestinationAuthMethodConfig"
+                  },
+                  "path_forwarding_disabled": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteDestination",
+        "summary": "Delete a destination",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "A single destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "ID of the destination"
+                    }
+                  },
+                  "required": ["id"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "delete"
+      }
+    },
+    "/destinations/{id}/archive": {
+      "put": {
+        "operationId": "archiveDestination",
+        "summary": "Archive a destination",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "A single destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Destination ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "archive"
+      }
+    },
+    "/destinations/{id}/unarchive": {
+      "put": {
+        "operationId": "unarchiveDestination",
+        "summary": "Unarchive a destination",
+        "description": "",
+        "tags": ["Destinations"],
+        "responses": {
+          "200": {
+            "description": "A single destination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Destination"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Destination ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "destination",
+        "x-fern-sdk-method-name": "unarchive"
+      }
+    },
+    "/bulk/events/retry": {
+      "get": {
+        "operationId": "getEventBulkRetries",
+        "summary": "Get events bulk retries",
+        "description": "",
+        "tags": ["Bulk retry events"],
+        "responses": {
+          "200": {
+            "description": "List of events bulk retries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperationPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cancelled_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry was cancelled"
+            }
+          },
+          {
+            "in": "query",
+            "name": "completed_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry completed"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry was created"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Bulk retry ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Bulk retry ID"
+                  }
+                }
+              ],
+              "description": "Filter by bulk retry IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Event ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Event ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by event IDs"
+                },
+                "status": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/EventStatus"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/EventStatus"
+                      }
+                    }
+                  ],
+                  "description": "Lifecyle status of the event"
+                },
+                "webhook_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Webhook ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Webhook ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by webhook connection IDs"
+                },
+                "destination_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Destination ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Destination ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by destination IDs"
+                },
+                "source_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Source ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Source ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by source IDs"
+                },
+                "attempts": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "Filter by number of attempts"
+                },
+                "response_status": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 200,
+                        "maximum": 600
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by HTTP response status code"
+                },
+                "successful_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by `successful_at` date using a date operator"
+                },
+                "created_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "Filter by `created_at` date using a date operator"
+                },
+                "error_code": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AttemptErrorCodes"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AttemptErrorCodes"
+                      }
+                    }
+                  ],
+                  "description": "Filter by error code code"
+                },
+                "cli_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by CLI IDs. `?[any]=true` operator for any CLI."
+                },
+                "last_attempt_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by `last_attempt_at` date using a date operator"
+                },
+                "search_term": {
+                  "type": "string",
+                  "minLength": 3,
+                  "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+                },
+                "headers": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data headers",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "body": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data body",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "parsed_query": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "URL Encoded string of the value to match partially to the path"
+                },
+                "cli_user_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "x-docs-hide": true
+                },
+                "issue_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                },
+                "event_data_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                },
+                "bulk_retry_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter for events to be included in the bulk retry, use query parameters of [Event](#events)",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query_partial_match",
+            "schema": {
+              "type": "boolean",
+              "description": "Allow partial filter match on query property"
+            }
+          },
+          {
+            "in": "query",
+            "name": "in_progress",
+            "schema": {
+              "type": "boolean",
+              "description": "Indicates if the bulk retry is currently in progress"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "eventBulkRetry",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createEventBulkRetry",
+        "summary": "Create an events bulk retry",
+        "description": "",
+        "tags": ["Bulk retry events"],
+        "responses": {
+          "200": {
+            "description": "A single events bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "eventBulkRetry",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "Event ID"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Event ID"
+                            }
+                          }
+                        ],
+                        "description": "Filter by event IDs"
+                      },
+                      "status": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/components/schemas/EventStatus"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/components/schemas/EventStatus"
+                            }
+                          }
+                        ],
+                        "description": "Lifecyle status of the event"
+                      },
+                      "webhook_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "Webhook ID"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Webhook ID"
+                            }
+                          }
+                        ],
+                        "description": "Filter by webhook connection IDs"
+                      },
+                      "destination_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "Destination ID"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Destination ID"
+                            }
+                          }
+                        ],
+                        "description": "Filter by destination IDs"
+                      },
+                      "source_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "Source ID"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Source ID"
+                            }
+                          }
+                        ],
+                        "description": "Filter by source IDs"
+                      },
+                      "attempts": {
+                        "anyOf": [
+                          {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "gte": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "le": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "lte": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "any": {
+                                "type": "boolean"
+                              },
+                              "all": {
+                                "type": "boolean"
+                              },
+                              "contains": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "Filter by number of attempts"
+                      },
+                      "response_status": {
+                        "anyOf": [
+                          {
+                            "type": "integer",
+                            "minimum": 200,
+                            "maximum": 600
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "integer",
+                                "minimum": 200,
+                                "maximum": 600
+                              },
+                              "gte": {
+                                "type": "integer",
+                                "minimum": 200,
+                                "maximum": 600
+                              },
+                              "le": {
+                                "type": "integer",
+                                "minimum": 200,
+                                "maximum": 600
+                              },
+                              "lte": {
+                                "type": "integer",
+                                "minimum": 200,
+                                "maximum": 600
+                              },
+                              "any": {
+                                "type": "boolean"
+                              },
+                              "all": {
+                                "type": "boolean"
+                              },
+                              "contains": {
+                                "type": "integer",
+                                "minimum": 200,
+                                "maximum": 600
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "integer",
+                              "minimum": 200,
+                              "maximum": 600
+                            }
+                          }
+                        ],
+                        "nullable": true,
+                        "description": "Filter by HTTP response status code"
+                      },
+                      "successful_at": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "gte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "le": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "lte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "any": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ],
+                        "nullable": true,
+                        "description": "Filter by `successful_at` date using a date operator"
+                      },
+                      "created_at": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "gte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "le": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "lte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "any": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "Filter by `created_at` date using a date operator"
+                      },
+                      "error_code": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/components/schemas/AttemptErrorCodes"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/components/schemas/AttemptErrorCodes"
+                            }
+                          }
+                        ],
+                        "description": "Filter by error code code"
+                      },
+                      "cli_id": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "any": {
+                                "type": "boolean"
+                              },
+                              "all": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "nullable": true,
+                        "description": "Filter by CLI IDs. `?[any]=true` operator for any CLI."
+                      },
+                      "last_attempt_at": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "gte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "le": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "lte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "any": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ],
+                        "nullable": true,
+                        "description": "Filter by `last_attempt_at` date using a date operator"
+                      },
+                      "search_term": {
+                        "type": "string",
+                        "minLength": 3,
+                        "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+                      },
+                      "headers": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "URL Encoded string of the JSON to match to the data headers",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      },
+                      "body": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "URL Encoded string of the JSON to match to the data body",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      },
+                      "parsed_query": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      },
+                      "path": {
+                        "type": "string",
+                        "description": "URL Encoded string of the value to match partially to the path"
+                      },
+                      "cli_user_id": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ],
+                        "nullable": true,
+                        "x-docs-hide": true
+                      },
+                      "issue_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255
+                            }
+                          }
+                        ],
+                        "x-docs-hide": true
+                      },
+                      "event_data_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255
+                            }
+                          }
+                        ],
+                        "x-docs-hide": true
+                      },
+                      "bulk_retry_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255
+                            }
+                          }
+                        ],
+                        "x-docs-hide": true
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "Filter properties for the events to be included in the bulk retry",
+                    "x-docs-force-simple-type": true,
+                    "x-docs-type": "JSON"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bulk/events/retry/plan": {
+      "get": {
+        "operationId": "generateEventBulkRetryPlan",
+        "summary": "Generate an events bulk retry plan",
+        "description": "",
+        "tags": ["Bulk retry events"],
+        "responses": {
+          "200": {
+            "description": "Events bulk retry plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "estimated_batch": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of batches required to complete the bulk retry"
+                    },
+                    "estimated_count": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of estimated events to be retried"
+                    },
+                    "progress": {
+                      "type": "number",
+                      "format": "float",
+                      "nullable": true,
+                      "description": "Progression of the batch operations, values 0 - 1"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Event ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Event ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by event IDs"
+                },
+                "status": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/EventStatus"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/EventStatus"
+                      }
+                    }
+                  ],
+                  "description": "Lifecyle status of the event"
+                },
+                "webhook_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Webhook ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Webhook ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by webhook connection IDs"
+                },
+                "destination_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Destination ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Destination ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by destination IDs"
+                },
+                "source_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Source ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Source ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by source IDs"
+                },
+                "attempts": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "Filter by number of attempts"
+                },
+                "response_status": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 200,
+                          "maximum": 600
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 200,
+                        "maximum": 600
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by HTTP response status code"
+                },
+                "successful_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by `successful_at` date using a date operator"
+                },
+                "created_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "Filter by `created_at` date using a date operator"
+                },
+                "error_code": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AttemptErrorCodes"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AttemptErrorCodes"
+                      }
+                    }
+                  ],
+                  "description": "Filter by error code code"
+                },
+                "cli_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by CLI IDs. `?[any]=true` operator for any CLI."
+                },
+                "last_attempt_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by `last_attempt_at` date using a date operator"
+                },
+                "search_term": {
+                  "type": "string",
+                  "minLength": 3,
+                  "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+                },
+                "headers": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data headers",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "body": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data body",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "parsed_query": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "URL Encoded string of the value to match partially to the path"
+                },
+                "cli_user_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "x-docs-hide": true
+                },
+                "issue_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                },
+                "event_data_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                },
+                "bulk_retry_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter properties for the events to be included in the bulk retry",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "eventBulkRetry",
+        "x-fern-sdk-method-name": "plan"
+      }
+    },
+    "/bulk/events/retry/{id}": {
+      "get": {
+        "operationId": "getEventBulkRetry",
+        "summary": "Get an events bulk retry",
+        "description": "",
+        "tags": ["Bulk retry events"],
+        "responses": {
+          "200": {
+            "description": "A single events bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bulk retry ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "eventBulkRetry",
+        "x-fern-sdk-method-name": "retrieve"
+      }
+    },
+    "/bulk/events/retry/{id}/cancel": {
+      "post": {
+        "operationId": "cancelEventBulkRetry",
+        "summary": "Cancel an events bulk retry",
+        "description": "",
+        "tags": ["Bulk retry events"],
+        "responses": {
+          "200": {
+            "description": "A single events bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bulk retry ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "eventBulkRetry",
+        "x-fern-sdk-method-name": "cancel"
+      }
+    },
+    "/events": {
+      "get": {
+        "operationId": "getEvents",
+        "summary": "Get events",
+        "description": "",
+        "tags": ["Events"],
+        "responses": {
+          "200": {
+            "description": "List of events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Event ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Event ID"
+                  }
+                }
+              ],
+              "description": "Filter by event IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/EventStatus"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EventStatus"
+                  }
+                }
+              ],
+              "description": "Lifecyle status of the event"
+            }
+          },
+          {
+            "in": "query",
+            "name": "webhook_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Webhook ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Webhook ID"
+                  }
+                }
+              ],
+              "description": "Filter by webhook connection IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "destination_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Destination ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Destination ID"
+                  }
+                }
+              ],
+              "description": "Filter by destination IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Source ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Source ID"
+                  }
+                }
+              ],
+              "description": "Filter by source IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "attempts",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "gte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "le": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "lte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by number of attempts"
+            }
+          },
+          {
+            "in": "query",
+            "name": "response_status",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 200,
+                  "maximum": 600
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "gte": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "le": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "lte": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "minimum": 200,
+                    "maximum": 600
+                  }
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by HTTP response status code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "successful_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by `successful_at` date using a date operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by `created_at` date using a date operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error_code",
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/AttemptErrorCodes"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AttemptErrorCodes"
+                  }
+                }
+              ],
+              "description": "Filter by error code code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cli_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by CLI IDs. `?[any]=true` operator for any CLI."
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_attempt_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by `last_attempt_at` date using a date operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search_term",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+            }
+          },
+          {
+            "in": "query",
+            "name": "headers",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the data headers",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "body",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the data body",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parsed_query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string",
+              "description": "URL Encoded string of the value to match partially to the path"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cli_user_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "nullable": true,
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "issue_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_data_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "bulk_retry_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "type": "string",
+              "enum": ["data"],
+              "description": "Include the data object in the event model",
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "enum": ["last_attempt_at", "created_at"],
+              "description": "Sort key"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "type": "string",
+              "enum": ["asc", "desc"],
+              "description": "Sort direction"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "event",
+        "x-fern-sdk-method-name": "list"
+      }
+    },
+    "/events/{id}": {
+      "get": {
+        "operationId": "getEvent",
+        "summary": "Get an event",
+        "description": "",
+        "tags": ["Events"],
+        "responses": {
+          "200": {
+            "description": "A single event",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Event ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "event",
+        "x-fern-sdk-method-name": "retrieve"
+      }
+    },
+    "/events/{id}/raw_body": {
+      "get": {
+        "operationId": "getRequestRawBody",
+        "summary": "Get a event raw body data",
+        "description": "",
+        "tags": ["Events"],
+        "responses": {
+          "200": {
+            "description": "A request raw body data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RawBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Event ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "event",
+        "x-fern-sdk-method-name": "retrieveBody"
+      }
+    },
+    "/events/{id}/retry": {
+      "post": {
+        "operationId": "retryEvent",
+        "summary": "Retry an event",
+        "description": "",
+        "tags": ["Events"],
+        "responses": {
+          "200": {
+            "description": "Retried event with event attempt",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetriedEvent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Event ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "event",
+        "x-fern-sdk-method-name": "retry"
+      }
+    },
+    "/events/{id}/mute": {
+      "put": {
+        "operationId": "muteEvent",
+        "summary": "Mute an event",
+        "description": "",
+        "tags": ["Events"],
+        "responses": {
+          "200": {
+            "description": "A single event",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Event ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "event",
+        "x-fern-sdk-method-name": "mute"
+      }
+    },
+    "/bulk/ignored-events/retry": {
+      "get": {
+        "operationId": "getIgnoredEventBulkRetries",
+        "summary": "Get ignored events bulk retries",
+        "description": "",
+        "tags": ["Bulk retry ignored events"],
+        "responses": {
+          "200": {
+            "description": "List of ignored events bulk retries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperationPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cancelled_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry was cancelled"
+            }
+          },
+          {
+            "in": "query",
+            "name": "completed_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry completed"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry was created"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Bulk retry ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Bulk retry ID"
+                  }
+                }
+              ],
+              "description": "Filter by bulk retry IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cause": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "description": "The cause of the ignored event"
+                },
+                "webhook_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "description": "Connection ID of the ignored event"
+                },
+                "transformation_id": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "The associated transformation ID (only applicable to the cause `TRANSFORMATION_FAILED`)"
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter by the bulk retry ignored event query object",
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query_partial_match",
+            "schema": {
+              "type": "boolean",
+              "description": "Allow partial filter match on query property"
+            }
+          },
+          {
+            "in": "query",
+            "name": "in_progress",
+            "schema": {
+              "type": "boolean",
+              "description": "Indicates if the bulk retry is currently in progress"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "ignoredEventBulkRetry",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createIgnoredEventBulkRetry",
+        "summary": "Create an ignored events bulk retry",
+        "description": "",
+        "tags": ["Bulk retry ignored events"],
+        "responses": {
+          "200": {
+            "description": "A single ignored events bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "ignoredEventBulkRetry",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "object",
+                    "properties": {
+                      "cause": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255
+                            }
+                          }
+                        ],
+                        "description": "The cause of the ignored event"
+                      },
+                      "webhook_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255
+                            }
+                          }
+                        ],
+                        "description": "Connection ID of the ignored event"
+                      },
+                      "transformation_id": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "The associated transformation ID (only applicable to the cause `TRANSFORMATION_FAILED`)"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "Filter by the bulk retry ignored event query object",
+                    "x-docs-type": "JSON"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bulk/ignored-events/retry/plan": {
+      "get": {
+        "operationId": "generateIgnoredEventBulkRetryPlan",
+        "summary": "Generate an ignored events bulk retry plan",
+        "description": "",
+        "tags": ["Bulk retry ignored events"],
+        "responses": {
+          "200": {
+            "description": "Ignored events bulk retry plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "estimated_batch": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of batches required to complete the bulk retry"
+                    },
+                    "estimated_count": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of estimated events to be retried"
+                    },
+                    "progress": {
+                      "type": "number",
+                      "format": "float",
+                      "nullable": true,
+                      "description": "Progression of the batch operations, values 0 - 1"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cause": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "description": "The cause of the ignored event"
+                },
+                "webhook_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "description": "Connection ID of the ignored event"
+                },
+                "transformation_id": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "The associated transformation ID (only applicable to the cause `TRANSFORMATION_FAILED`)"
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter by the bulk retry ignored event query object",
+              "x-docs-type": "JSON"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "ignoredEventBulkRetry",
+        "x-fern-sdk-method-name": "plan"
+      }
+    },
+    "/bulk/ignored-events/retry/{id}": {
+      "get": {
+        "operationId": "getIgnoredEventBulkRetry",
+        "summary": "Get an ignored events bulk retry",
+        "description": "",
+        "tags": ["Bulk retry ignored events"],
+        "responses": {
+          "200": {
+            "description": "A single ignored events bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bulk retry ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "ignoredEventBulkRetry",
+        "x-fern-sdk-method-name": "retrieve"
+      }
+    },
+    "/bulk/ignored-events/retry/{id}/cancel": {
+      "post": {
+        "operationId": "cancelIgnoredEventBulkRetry",
+        "summary": "Cancel an ignored events bulk retry",
+        "description": "",
+        "tags": ["Bulk retry ignored events"],
+        "responses": {
+          "200": {
+            "description": "A single ignored events bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bulk retry ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "ignoredEventBulkRetry",
+        "x-fern-sdk-method-name": "cancel"
+      }
+    },
+    "/integrations": {
+      "get": {
+        "operationId": "getIntegrations",
+        "summary": "Get integrations",
+        "description": "",
+        "tags": ["Integrations"],
+        "responses": {
+          "200": {
+            "description": "List of integrations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "label",
+            "schema": {
+              "type": "string",
+              "description": "The integration label"
+            }
+          },
+          {
+            "in": "query",
+            "name": "provider",
+            "schema": {
+              "$ref": "#/components/schemas/IntegrationProvider"
+            }
+          }
+        ],
+        "x-fern-ignore": true
+      },
+      "post": {
+        "operationId": "createIntegration",
+        "summary": "Create an integration",
+        "description": "",
+        "tags": ["Integrations"],
+        "responses": {
+          "200": {
+            "description": "A single integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-ignore": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "Label of the integration"
+                  },
+                  "configs": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/HMACIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/APIKeyIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/HandledAPIKeyIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/HandledHMACConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/BasicAuthIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ShopifyIntegrationConfigs"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Decrypted Key/Value object of the associated configuration for that provider",
+                    "x-docs-force-simple-type": true,
+                    "x-docs-type": "object"
+                  },
+                  "provider": {
+                    "$ref": "#/components/schemas/IntegrationProvider"
+                  },
+                  "features": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/IntegrationFeature"
+                    },
+                    "description": "List of features to enable (see features list above)",
+                    "x-docs-force-simple-type": true,
+                    "x-docs-type": "Array of string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/integrations/{id}": {
+      "get": {
+        "operationId": "getIntegration",
+        "summary": "Get an integration",
+        "description": "",
+        "tags": ["Integrations"],
+        "responses": {
+          "200": {
+            "description": "A single integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Integration ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-ignore": true
+      },
+      "put": {
+        "operationId": "updateIntegration",
+        "summary": "Update an integration",
+        "description": "",
+        "tags": ["Integrations"],
+        "responses": {
+          "200": {
+            "description": "A single integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Integration ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-ignore": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string",
+                    "description": "Label of the integration"
+                  },
+                  "configs": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/HMACIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/APIKeyIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/HandledAPIKeyIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/HandledHMACConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/BasicAuthIntegrationConfigs"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ShopifyIntegrationConfigs"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Decrypted Key/Value object of the associated configuration for that provider",
+                    "x-docs-force-simple-type": true,
+                    "x-docs-type": "object"
+                  },
+                  "provider": {
+                    "$ref": "#/components/schemas/IntegrationProvider"
+                  },
+                  "features": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/IntegrationFeature"
+                    },
+                    "description": "List of features to enable (see features list above)",
+                    "x-docs-force-simple-type": true,
+                    "x-docs-type": "Array of string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteIntegration",
+        "summary": "Delete an integration",
+        "description": "",
+        "tags": ["Integrations"],
+        "responses": {
+          "200": {
+            "description": "An object with deleted integration id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeletedIntegration"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Integration ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-ignore": true
+      }
+    },
+    "/integrations/{id}/attach/{source_id}": {
+      "put": {
+        "operationId": "attachIntegrationToSource",
+        "summary": "Attach an integration to a source",
+        "description": "",
+        "tags": ["Integrations"],
+        "responses": {
+          "200": {
+            "description": "Attach operation success status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachedIntegrationToSource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Integration ID"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "source_id",
+            "schema": {
+              "type": "string",
+              "description": "Source ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-ignore": true
+      }
+    },
+    "/integrations/{id}/detach/{source_id}": {
+      "put": {
+        "operationId": "detachIntegrationToSource",
+        "summary": "Detach an integration from a source",
+        "description": "",
+        "tags": ["Integrations"],
+        "responses": {
+          "200": {
+            "description": "Detach operation success status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetachedIntegrationFromSource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Integration ID"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "source_id",
+            "schema": {
+              "type": "string",
+              "description": "Source ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-ignore": true
+      }
+    },
+    "/issues": {
+      "get": {
+        "operationId": "getIssues",
+        "summary": "Get issues",
+        "description": "",
+        "tags": ["Issues"],
+        "responses": {
+          "200": {
+            "description": "List of issues",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueWithDataPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "example": "iss_YXKv5OdJXCiVwkPhGy"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "example": "iss_YXKv5OdJXCiVwkPhGy"
+                  }
+                }
+              ],
+              "description": "Filter by Issue IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "issue_trigger_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Issue trigger ID",
+                  "example": "it_BXKv5OdJXCiVwkPhGy"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Issue trigger ID",
+                    "example": "it_BXKv5OdJXCiVwkPhGy"
+                  }
+                }
+              ],
+              "description": "Filter by Issue trigger IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["delivery", "transformation", "backpressure"],
+                  "description": "Issue type",
+                  "example": "delivery"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["delivery", "transformation", "backpressure"],
+                    "description": "Issue type",
+                    "example": "delivery"
+                  }
+                }
+              ],
+              "description": "Filter by Issue types"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["OPENED", "IGNORED", "ACKNOWLEDGED", "RESOLVED"],
+                  "description": "Issue status",
+                  "example": "OPENED"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["OPENED", "IGNORED", "ACKNOWLEDGED", "RESOLVED"],
+                    "description": "Issue status",
+                    "example": "OPENED"
+                  }
+                }
+              ],
+              "description": "Filter by Issue statuses"
+            }
+          },
+          {
+            "in": "query",
+            "name": "merged_with",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "Issue ID",
+                  "example": "iss_AXKv3OdJXCiKlkPhDz"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "Issue ID",
+                    "example": "iss_AXKv3OdJXCiKlkPhDz"
+                  }
+                }
+              ],
+              "description": "Filter by Merged Issue IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregation_keys",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "webhook_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "response_status": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "format": "float"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "number",
+                        "format": "float"
+                      }
+                    }
+                  ]
+                },
+                "error_code": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AttemptErrorCodes"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AttemptErrorCodes"
+                      }
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter by aggregation keys",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by created dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "first_seen_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by first seen dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_seen_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by last seen dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dismissed_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by dismissed dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": [
+                    "created_at",
+                    "first_seen_at",
+                    "last_seen_at",
+                    "opened_at",
+                    "status"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": [
+                      "created_at",
+                      "first_seen_at",
+                      "last_seen_at",
+                      "opened_at",
+                      "status"
+                    ]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "issue",
+        "x-fern-sdk-method-name": "list"
+      }
+    },
+    "/issues/count": {
+      "get": {
+        "operationId": "getIssueCount",
+        "summary": "Get the number of issues",
+        "description": "",
+        "tags": ["Issues"],
+        "responses": {
+          "200": {
+            "description": "Issue count",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueCount"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "example": "iss_YXKv5OdJXCiVwkPhGy"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "example": "iss_YXKv5OdJXCiVwkPhGy"
+                  }
+                }
+              ],
+              "description": "Filter by Issue IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "issue_trigger_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Issue trigger ID",
+                  "example": "it_BXKv5OdJXCiVwkPhGy"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Issue trigger ID",
+                    "example": "it_BXKv5OdJXCiVwkPhGy"
+                  }
+                }
+              ],
+              "description": "Filter by Issue trigger IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["delivery", "transformation", "backpressure"],
+                  "description": "Issue type",
+                  "example": "delivery"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["delivery", "transformation", "backpressure"],
+                    "description": "Issue type",
+                    "example": "delivery"
+                  }
+                }
+              ],
+              "description": "Filter by Issue types"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["OPENED", "IGNORED", "ACKNOWLEDGED", "RESOLVED"],
+                  "description": "Issue status",
+                  "example": "OPENED"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["OPENED", "IGNORED", "ACKNOWLEDGED", "RESOLVED"],
+                    "description": "Issue status",
+                    "example": "OPENED"
+                  }
+                }
+              ],
+              "description": "Filter by Issue statuses"
+            }
+          },
+          {
+            "in": "query",
+            "name": "merged_with",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "Issue ID",
+                  "example": "iss_AXKv3OdJXCiKlkPhDz"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "description": "Issue ID",
+                    "example": "iss_AXKv3OdJXCiKlkPhDz"
+                  }
+                }
+              ],
+              "description": "Filter by Merged Issue IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregation_keys",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "webhook_id": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "response_status": {
+                  "anyOf": [
+                    {
+                      "type": "number",
+                      "format": "float"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "number",
+                        "format": "float"
+                      }
+                    }
+                  ]
+                },
+                "error_code": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AttemptErrorCodes"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AttemptErrorCodes"
+                      }
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter by aggregation keys",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by created dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "first_seen_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by first seen dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_seen_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by last seen dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dismissed_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by dismissed dates"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": [
+                    "created_at",
+                    "first_seen_at",
+                    "last_seen_at",
+                    "opened_at",
+                    "status"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": [
+                      "created_at",
+                      "first_seen_at",
+                      "last_seen_at",
+                      "opened_at",
+                      "status"
+                    ]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "issue",
+        "x-fern-sdk-method-name": "count"
+      }
+    },
+    "/issues/{id}": {
+      "get": {
+        "operationId": "getIssue",
+        "summary": "Get a single issue",
+        "description": "",
+        "tags": ["Issues"],
+        "responses": {
+          "200": {
+            "description": "A single issue",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssueWithData"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issue",
+        "x-fern-sdk-method-name": "retrieve"
+      },
+      "put": {
+        "operationId": "updateIssue",
+        "summary": "Update issue",
+        "description": "",
+        "tags": ["Issues"],
+        "responses": {
+          "200": {
+            "description": "Updated issue",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Issue"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issue",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": ["OPENED", "IGNORED", "ACKNOWLEDGED", "RESOLVED"],
+                    "description": "New status"
+                  }
+                },
+                "required": ["status"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "dismissIssue",
+        "summary": "Dismiss an issue",
+        "description": "",
+        "tags": ["Issues"],
+        "responses": {
+          "200": {
+            "description": "Dismissed issue",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Issue"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Issue ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "issue",
+        "x-fern-sdk-method-name": "dismiss"
+      }
+    },
+    "/requests": {
+      "get": {
+        "operationId": "getRequests",
+        "summary": "Get requests",
+        "description": "",
+        "tags": ["Requests"],
+        "responses": {
+          "200": {
+            "description": "List of requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RequestPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Request ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Request ID"
+                  }
+                }
+              ],
+              "description": "Filter by requests IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string",
+              "enum": ["accepted", "rejected"],
+              "description": "Filter by status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rejection_cause",
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RequestRejectionCause"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RequestRejectionCause"
+                  }
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by rejection cause"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Source ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Source ID"
+                  }
+                }
+              ],
+              "description": "Filter by source IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verified",
+            "schema": {
+              "type": "boolean",
+              "description": "Filter by verification status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search_term",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+            }
+          },
+          {
+            "in": "query",
+            "name": "headers",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the data headers",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "body",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the data body",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parsed_query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string",
+              "description": "URL Encoded string of the value to match partially to the path"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ignored_count",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "gte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "le": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "lte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              ],
+              "description": "Filter by count of ignored events"
+            }
+          },
+          {
+            "in": "query",
+            "name": "events_count",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "gte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "le": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "lte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "minimum": 0
+                  }
+                }
+              ],
+              "description": "Filter by count of events"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ingested_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by event ingested date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "bulk_retry_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "type": "string",
+              "enum": ["data"],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "enum": ["ingested_at", "created_at"],
+              "description": "Sort key"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "type": "string",
+              "enum": ["asc", "desc"],
+              "description": "Sort direction"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "request",
+        "x-fern-sdk-method-name": "list"
+      }
+    },
+    "/requests/{id}": {
+      "get": {
+        "operationId": "getRequest",
+        "summary": "Get a request",
+        "description": "",
+        "tags": ["Requests"],
+        "responses": {
+          "200": {
+            "description": "A single request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Request"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Request ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "request",
+        "x-fern-sdk-method-name": "retrieve"
+      }
+    },
+    "/requests/{id}/raw_body": {
+      "get": {
+        "operationId": "getRequestRawBody",
+        "summary": "Get a request raw body data",
+        "description": "",
+        "tags": ["Requests"],
+        "responses": {
+          "200": {
+            "description": "A request raw body data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RawBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Request ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "request",
+        "x-fern-sdk-method-name": "retrieveBody"
+      }
+    },
+    "/requests/{id}/retry": {
+      "post": {
+        "operationId": "retryRequest",
+        "summary": "Retry a request",
+        "description": "",
+        "tags": ["Requests"],
+        "responses": {
+          "200": {
+            "description": "Retry request operation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetryRequest"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Request ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "request",
+        "x-fern-sdk-method-name": "retry",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "webhook_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Webhook ID"
+                    },
+                    "description": "Subset of webhook_ids to re-run the event logic on. Useful to retry only specific ignored_events"
+                  }
+                },
+                "required": ["webhook_ids"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/requests/{id}/events": {
+      "get": {
+        "operationId": "getRequestEvents",
+        "summary": "Get request events",
+        "description": "",
+        "tags": ["Requests"],
+        "responses": {
+          "200": {
+            "description": "List of events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Event ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Event ID"
+                  }
+                }
+              ],
+              "description": "Filter by event IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/EventStatus"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EventStatus"
+                  }
+                }
+              ],
+              "description": "Lifecyle status of the event"
+            }
+          },
+          {
+            "in": "query",
+            "name": "webhook_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Webhook ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Webhook ID"
+                  }
+                }
+              ],
+              "description": "Filter by webhook connection IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "destination_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Destination ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Destination ID"
+                  }
+                }
+              ],
+              "description": "Filter by destination IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Source ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Source ID"
+                  }
+                }
+              ],
+              "description": "Filter by source IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "attempts",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "gte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "le": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "lte": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by number of attempts"
+            }
+          },
+          {
+            "in": "query",
+            "name": "response_status",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 200,
+                  "maximum": 600
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "gte": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "le": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "lte": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "integer",
+                      "minimum": 200,
+                      "maximum": 600
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "minimum": 200,
+                    "maximum": 600
+                  }
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by HTTP response status code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "successful_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by `successful_at` date using a date operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by `created_at` date using a date operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error_code",
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/AttemptErrorCodes"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AttemptErrorCodes"
+                  }
+                }
+              ],
+              "description": "Filter by error code code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cli_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by CLI IDs. `?[any]=true` operator for any CLI."
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_attempt_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "nullable": true,
+              "description": "Filter by `last_attempt_at` date using a date operator"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search_term",
+            "schema": {
+              "type": "string",
+              "minLength": 3,
+              "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+            }
+          },
+          {
+            "in": "query",
+            "name": "headers",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the data headers",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "body",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the data body",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "parsed_query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": false
+                }
+              ],
+              "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "type": "string",
+              "description": "URL Encoded string of the value to match partially to the path"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cli_user_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ],
+              "nullable": true,
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "issue_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_data_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "bulk_retry_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "type": "string",
+              "enum": ["data"],
+              "description": "Include the data object in the event model",
+              "x-docs-hide": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "enum": ["last_attempt_at", "created_at"],
+              "description": "Sort key"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "type": "string",
+              "enum": ["asc", "desc"],
+              "description": "Sort direction"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Request ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "request",
+        "x-fern-sdk-method-name": "listEvent"
+      }
+    },
+    "/requests/{id}/ignored_events": {
+      "get": {
+        "operationId": "getRequestIgnoredEvents",
+        "summary": "Get request ignored events",
+        "description": "",
+        "tags": ["Requests"],
+        "responses": {
+          "200": {
+            "description": "List of ignored events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IgnoredEventPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Event ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Event ID"
+                  }
+                }
+              ],
+              "description": "Filter by ignored events IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Request ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "request",
+        "x-fern-sdk-method-name": "listIgnoredEvent"
+      }
+    },
+    "/bulk/requests/retry": {
+      "get": {
+        "operationId": "getRequestBulkRetries",
+        "summary": "Get request bulk retries",
+        "description": "",
+        "tags": ["Bulk retry requests"],
+        "responses": {
+          "200": {
+            "description": "List of request bulk retries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperationPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "cancelled_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry was cancelled"
+            }
+          },
+          {
+            "in": "query",
+            "name": "completed_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry completed"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by date the bulk retry was created"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "Bulk retry ID"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "Bulk retry ID"
+                  }
+                }
+              ],
+              "description": "Filter by bulk retry IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "in_progress",
+            "schema": {
+              "type": "boolean",
+              "description": "Indicates if the bulk retry is currently in progress"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Request ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Request ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by requests IDs"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": ["accepted", "rejected"],
+                  "description": "Filter by status"
+                },
+                "rejection_cause": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RequestRejectionCause"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RequestRejectionCause"
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by rejection cause"
+                },
+                "source_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Source ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Source ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by source IDs"
+                },
+                "verified": {
+                  "type": "boolean",
+                  "description": "Filter by verification status"
+                },
+                "search_term": {
+                  "type": "string",
+                  "minLength": 3,
+                  "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+                },
+                "headers": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data headers",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "body": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data body",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "parsed_query": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "URL Encoded string of the value to match partially to the path"
+                },
+                "ignored_count": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    }
+                  ],
+                  "description": "Filter by count of ignored events"
+                },
+                "events_count": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    }
+                  ],
+                  "description": "Filter by count of events"
+                },
+                "ingested_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "Filter by event ingested date"
+                },
+                "bulk_retry_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                },
+                "include": {
+                  "type": "string",
+                  "enum": ["data"],
+                  "x-docs-hide": true
+                },
+                "order_by": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["ingested_at", "created_at"],
+                  "description": "Sort key"
+                },
+                "dir": {
+                  "type": "string",
+                  "enum": ["asc", "desc"],
+                  "description": "Sort direction"
+                },
+                "limit": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 255,
+                  "description": "Result set size"
+                },
+                "next": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "The ID to provide in the query to get the next set of results"
+                },
+                "prev": {
+                  "type": "string",
+                  "maxLength": 255,
+                  "description": "The ID to provide in the query to get the previous set of results"
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter properties for the events to be included in the bulk retry, use query parameters of [Requests](#requests)",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query_partial_match",
+            "schema": {
+              "type": "boolean",
+              "description": "Allow partial filter match on query property"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "requestBulkRetry",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createRequestBulkRetry",
+        "summary": "Create a requests bulk retry",
+        "description": "",
+        "tags": ["Bulk retry requests"],
+        "responses": {
+          "200": {
+            "description": "A single requests bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "requestBulkRetry",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "Request ID"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Request ID"
+                            }
+                          }
+                        ],
+                        "description": "Filter by requests IDs"
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": ["accepted", "rejected"],
+                        "description": "Filter by status"
+                      },
+                      "rejection_cause": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/components/schemas/RequestRejectionCause"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "$ref": "#/components/schemas/RequestRejectionCause"
+                            }
+                          }
+                        ],
+                        "nullable": true,
+                        "description": "Filter by rejection cause"
+                      },
+                      "source_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255,
+                            "description": "Source ID"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255,
+                              "description": "Source ID"
+                            }
+                          }
+                        ],
+                        "description": "Filter by source IDs"
+                      },
+                      "verified": {
+                        "type": "boolean",
+                        "description": "Filter by verification status"
+                      },
+                      "search_term": {
+                        "type": "string",
+                        "minLength": 3,
+                        "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+                      },
+                      "headers": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "URL Encoded string of the JSON to match to the data headers",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      },
+                      "body": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "URL Encoded string of the JSON to match to the data body",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      },
+                      "parsed_query": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      },
+                      "path": {
+                        "type": "string",
+                        "description": "URL Encoded string of the value to match partially to the path"
+                      },
+                      "ignored_count": {
+                        "anyOf": [
+                          {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "gte": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "le": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "lte": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "any": {
+                                "type": "boolean"
+                              },
+                              "all": {
+                                "type": "boolean"
+                              },
+                              "contains": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
+                          }
+                        ],
+                        "description": "Filter by count of ignored events"
+                      },
+                      "events_count": {
+                        "anyOf": [
+                          {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "gte": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "le": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "lte": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "any": {
+                                "type": "boolean"
+                              },
+                              "all": {
+                                "type": "boolean"
+                              },
+                              "contains": {
+                                "type": "integer",
+                                "minimum": 0
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
+                          }
+                        ],
+                        "description": "Filter by count of events"
+                      },
+                      "ingested_at": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "gt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "gte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "le": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "lte": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "any": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ],
+                        "description": "Filter by event ingested date"
+                      },
+                      "bulk_retry_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "maxLength": 255
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "maxLength": 255
+                            }
+                          }
+                        ],
+                        "x-docs-hide": true
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "Filter properties for the events to be included in the bulk retry, use query parameters of [Requests](#requests)",
+                    "x-docs-force-simple-type": true,
+                    "x-docs-type": "JSON"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bulk/requests/retry/plan": {
+      "get": {
+        "operationId": "generateRequestBulkRetryPlan",
+        "summary": "Generate a requests bulk retry plan",
+        "description": "",
+        "tags": ["Bulk retry requests"],
+        "responses": {
+          "200": {
+            "description": "Requests bulk retry plan",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "estimated_batch": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of batches required to complete the bulk retry"
+                    },
+                    "estimated_count": {
+                      "type": "integer",
+                      "nullable": true,
+                      "description": "Number of estimated events to be retried"
+                    },
+                    "progress": {
+                      "type": "number",
+                      "format": "float",
+                      "nullable": true,
+                      "description": "Progression of the batch operations, values 0 - 1"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Request ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Request ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by requests IDs"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": ["accepted", "rejected"],
+                  "description": "Filter by status"
+                },
+                "rejection_cause": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/RequestRejectionCause"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RequestRejectionCause"
+                      }
+                    }
+                  ],
+                  "nullable": true,
+                  "description": "Filter by rejection cause"
+                },
+                "source_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Source ID"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Source ID"
+                      }
+                    }
+                  ],
+                  "description": "Filter by source IDs"
+                },
+                "verified": {
+                  "type": "boolean",
+                  "description": "Filter by verification status"
+                },
+                "search_term": {
+                  "type": "string",
+                  "minLength": 3,
+                  "description": "URL Encoded string of the value to match partially to the body, headers, parsed_query or path"
+                },
+                "headers": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data headers",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "body": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the data body",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "parsed_query": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {},
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "URL Encoded string of the JSON to match to the parsed query (JSON representation of the query)",
+                  "x-docs-force-simple-type": true,
+                  "x-docs-type": "JSON"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "URL Encoded string of the value to match partially to the path"
+                },
+                "ignored_count": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    }
+                  ],
+                  "description": "Filter by count of ignored events"
+                },
+                "events_count": {
+                  "anyOf": [
+                    {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "gte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "le": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "lte": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "any": {
+                          "type": "boolean"
+                        },
+                        "all": {
+                          "type": "boolean"
+                        },
+                        "contains": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    }
+                  ],
+                  "description": "Filter by count of events"
+                },
+                "ingested_at": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "gt": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "gte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "le": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "lte": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "any": {
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "Filter by event ingested date"
+                },
+                "bulk_retry_id": {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "maxLength": 255
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "maxLength": 255
+                      }
+                    }
+                  ],
+                  "x-docs-hide": true
+                }
+              },
+              "additionalProperties": false,
+              "description": "Filter properties for the events to be included in the bulk retry, use query parameters of [Requests](#requests)",
+              "x-docs-force-simple-type": true,
+              "x-docs-type": "JSON"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "requestBulkRetry",
+        "x-fern-sdk-method-name": "plan"
+      }
+    },
+    "/bulk/requests/retry/{id}": {
+      "get": {
+        "operationId": "getRequestBulkRetry",
+        "summary": "Get a requests bulk retry",
+        "description": "",
+        "tags": ["Bulk retry requests"],
+        "responses": {
+          "200": {
+            "description": "A single requests bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bulk retry ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "requestBulkRetry",
+        "x-fern-sdk-method-name": "retrieve"
+      }
+    },
+    "/bulk/requests/retry/{id}/cancel": {
+      "post": {
+        "operationId": "cancelRequestBulkRetry",
+        "summary": "Cancel a requests bulk retry",
+        "description": "",
+        "tags": ["Bulk retry requests"],
+        "responses": {
+          "200": {
+            "description": "A single requests bulk retry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchOperation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Bulk retry ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "requestBulkRetry",
+        "x-fern-sdk-method-name": "cancel"
+      }
+    },
+    "/sources": {
+      "get": {
+        "operationId": "getSources",
+        "summary": "Get sources",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "List of sources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourcePaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by source IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[A-z0-9-_]+$",
+                  "maxLength": 155
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "gte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "le": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "lte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "The source name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "schema": {
+              "type": "boolean",
+              "description": "Include archived resources in the response"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Date the source was archived"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createSource",
+        "summary": "Create a source",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "A single source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique name for the source"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the source"
+                  },
+                  "allowed_http_methods": {
+                    "$ref": "#/components/schemas/SourceAllowedHTTPMethod"
+                  },
+                  "custom_response": {
+                    "$ref": "#/components/schemas/SourceCustomResponse"
+                  },
+                  "verification": {
+                    "$ref": "#/components/schemas/VerificationConfig"
+                  }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "upsertSource",
+        "summary": "Update or create a source",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "A single source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "upsert",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique name for the source"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the source"
+                  },
+                  "allowed_http_methods": {
+                    "$ref": "#/components/schemas/SourceAllowedHTTPMethod"
+                  },
+                  "custom_response": {
+                    "$ref": "#/components/schemas/SourceCustomResponse"
+                  },
+                  "verification": {
+                    "$ref": "#/components/schemas/VerificationConfig"
+                  }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}": {
+      "get": {
+        "operationId": "getSource",
+        "summary": "Get a source",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "A single source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include",
+            "schema": {
+              "type": "string",
+              "enum": ["verification.configs"]
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Source ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "retrieve"
+      },
+      "put": {
+        "operationId": "updateSource",
+        "summary": "Update a source",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "A single source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Source ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique name for the source"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the source"
+                  },
+                  "allowed_http_methods": {
+                    "$ref": "#/components/schemas/SourceAllowedHTTPMethod"
+                  },
+                  "custom_response": {
+                    "$ref": "#/components/schemas/SourceCustomResponse"
+                  },
+                  "verification": {
+                    "$ref": "#/components/schemas/VerificationConfig"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteSource",
+        "summary": "Delete a source",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "A single source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "ID of the source"
+                    }
+                  },
+                  "required": ["id"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "delete"
+      }
+    },
+    "/sources/{id}/archive": {
+      "put": {
+        "operationId": "archiveSource",
+        "summary": "Archive a source",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "A single source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Source ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "archive"
+      }
+    },
+    "/sources/{id}/unarchive": {
+      "put": {
+        "operationId": "unarchiveSource",
+        "summary": "Unarchive a source",
+        "description": "",
+        "tags": ["Sources"],
+        "responses": {
+          "200": {
+            "description": "A single source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Source ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "source",
+        "x-fern-sdk-method-name": "unarchive"
+      }
+    },
+    "/notifications/webhooks": {
+      "put": {
+        "operationId": "toggleWebhookNotifications",
+        "summary": "Toggle webhook notifications for the workspace",
+        "description": "",
+        "tags": ["Notifications"],
+        "responses": {
+          "200": {
+            "description": "Toggle operation status response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToggleWebhookNotifications"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "notification",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable webhook notifications on the workspace"
+                  },
+                  "topics": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/TopicsValue"
+                    },
+                    "description": "List of topics to send notifications for"
+                  },
+                  "source_id": {
+                    "type": "string",
+                    "description": "The Hookdeck Source to send the webhook to"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{team_id}/custom_domains": {
+      "post": {
+        "operationId": "addCustomDomain",
+        "summary": "Add a custom domain to the workspace",
+        "description": "",
+        "tags": ["Notifications"],
+        "responses": {
+          "200": {
+            "description": "Custom domain successfuly added",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddCustomHostname"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "team_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "customDomain",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddCustomHostname"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listCustomDomains",
+        "summary": "List all custom domains and their verification statuses for the workspace",
+        "description": "",
+        "tags": ["Notifications"],
+        "responses": {
+          "200": {
+            "description": "List of custom domains",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCustomDomainSchema"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "team_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "customDomain",
+        "x-fern-sdk-method-name": "list"
+      }
+    },
+    "/teams/{team_id}/custom_domains/{domain_id}": {
+      "delete": {
+        "operationId": "deleteCustomDomain",
+        "summary": "Removes a custom domain from the workspace",
+        "description": "",
+        "tags": ["Notifications"],
+        "responses": {
+          "200": {
+            "description": "Custom domain successfuly removed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteCustomDomainSchema"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "team_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "domain_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "customDomain",
+        "x-fern-sdk-method-name": "delete"
+      }
+    },
+    "/transformations": {
+      "get": {
+        "operationId": "getTransformations",
+        "summary": "Get transformations",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "List of transformations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransformationPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by transformation IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[A-z0-9-_]+$",
+                  "maxLength": 155,
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by transformation name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createTransformation",
+        "summary": "Create a transformation",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "A single transformation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transformation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique, human-friendly name for the transformation"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "JavaScript code to be executed as string"
+                  },
+                  "env": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Key-value environment variables to be passed to the transformation"
+                  }
+                },
+                "required": ["name", "code"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "upsertTransformation",
+        "summary": "Update or create a transformation",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "A single transformation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transformation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "upsert",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique, human-friendly name for the transformation"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "JavaScript code to be executed as string"
+                  },
+                  "env": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Key-value environment variables to be passed to the transformation"
+                  }
+                },
+                "required": ["name", "code"],
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transformations/{id}": {
+      "get": {
+        "operationId": "getTransformation",
+        "summary": "Get a transformation",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "A single transformation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transformation"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Transformation ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "retrieve"
+      },
+      "put": {
+        "operationId": "updateTransformation",
+        "summary": "Update a transformation",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "A single transformation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transformation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Transformation ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "description": "A unique, human-friendly name for the transformation"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "JavaScript code to be executed"
+                  },
+                  "env": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Key-value environment variables to be passed to the transformation"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transformations/run": {
+      "put": {
+        "operationId": "testTransformation",
+        "summary": "Test a transformation code",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "Transformation run output",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransformationExecutorOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "run",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "env": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Key-value environment variables to be passed to the transformation"
+                  },
+                  "webhook_id": {
+                    "type": "string",
+                    "description": "ID of the connection to use for the execution `context`"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "JavaScript code to be executed"
+                  },
+                  "transformation_id": {
+                    "type": "string",
+                    "description": "Transformation ID"
+                  },
+                  "request": {
+                    "type": "object",
+                    "properties": {
+                      "headers": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Headers of the request",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      },
+                      "body": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false,
+                            "x-docs-force-simple-type": true,
+                            "x-docs-type": "JSON"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Body of the request",
+                        "x-docs-force-simple-type": true
+                      },
+                      "path": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Path of the request"
+                      },
+                      "query": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "String representation of the query params of the request"
+                      },
+                      "parsed_query": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false,
+                        "description": "JSON representation of the query params",
+                        "x-docs-force-simple-type": true,
+                        "x-docs-type": "JSON"
+                      }
+                    },
+                    "required": ["headers"],
+                    "additionalProperties": false,
+                    "description": "Request input to use for the transformation execution"
+                  },
+                  "event_id": {
+                    "type": "string",
+                    "x-docs-hide": true
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/transformations/{id}/executions": {
+      "get": {
+        "operationId": "getTransformationExecutions",
+        "summary": "Get transformation executions",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "List of transformation executions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransformationExecutionPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "log_level",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["debug", "info", "warn", "error", "fatal"],
+                  "nullable": true
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["debug", "info", "warn", "error", "fatal"],
+                    "nullable": true
+                  }
+                }
+              ],
+              "description": "Log level of the execution"
+            }
+          },
+          {
+            "in": "query",
+            "name": "webhook_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "ID of the connection the execution was run for"
+            }
+          },
+          {
+            "in": "query",
+            "name": "issue_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "ID of the associated issue"
+            }
+          },
+          {
+            "in": "query",
+            "name": "created_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "ISO date of the transformation's execution"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": ["created_at"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": ["created_at"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Transformation ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "listExecution"
+      }
+    },
+    "/transformations/{id}/executions/{execution_id}": {
+      "get": {
+        "operationId": "getTransformationExecution",
+        "summary": "Get a transformation execution",
+        "description": "",
+        "tags": ["Transformations"],
+        "responses": {
+          "200": {
+            "description": "A single transformation execution",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransformationExecution"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Transformation ID"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "execution_id",
+            "schema": {
+              "type": "string",
+              "description": "Execution ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "transformation",
+        "x-fern-sdk-method-name": "retrieveExecution"
+      }
+    },
+    "/connections": {
+      "get": {
+        "operationId": "getConnections",
+        "summary": "Get connections",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "List of connections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionPaginatedResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by connection IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "pattern": "^[A-z0-9-_]+$",
+                  "maxLength": 155,
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    },
+                    "all": {
+                      "type": "boolean"
+                    },
+                    "contains": {
+                      "type": "string",
+                      "pattern": "^[A-z0-9-_]+$",
+                      "maxLength": 155,
+                      "nullable": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Filter by connection name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "destination_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by associated destination IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by associated source IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "schema": {
+              "type": "boolean",
+              "description": "Include archived resources in the response"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Date the connection was archived"
+            }
+          },
+          {
+            "in": "query",
+            "name": "full_name",
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9-_>\\s]+$",
+              "maxLength": 155,
+              "description": "Fuzzy match the concatenated source and connection name. The source name and connection name must be separated by \" -> \""
+            }
+          },
+          {
+            "in": "query",
+            "name": "paused_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Date the connection was paused"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255,
+                  "enum": [
+                    "created_at",
+                    "updated_at",
+                    "sources.updated_at",
+                    "sources.created_at",
+                    "destinations.updated_at",
+                    "destinations.created_at"
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "enum": [
+                      "created_at",
+                      "updated_at",
+                      "sources.updated_at",
+                      "sources.created_at",
+                      "destinations.updated_at",
+                      "destinations.created_at"
+                    ]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort key(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dir",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["asc", "desc"]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": ["asc", "desc"]
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                }
+              ],
+              "description": "Sort direction(s)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255,
+              "description": "Result set size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "next",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the next set of results"
+            }
+          },
+          {
+            "in": "query",
+            "name": "prev",
+            "schema": {
+              "type": "string",
+              "maxLength": 255,
+              "description": "The ID to provide in the query to get the previous set of results"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "list"
+      },
+      "post": {
+        "operationId": "createConnection",
+        "summary": "Create a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "nullable": true,
+                    "description": "A unique name of the connection for the source"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the connection"
+                  },
+                  "destination_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "nullable": true,
+                    "description": "ID of a destination to bind to the connection"
+                  },
+                  "source_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "nullable": true,
+                    "description": "ID of a source to bind to the connection"
+                  },
+                  "destination": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-z0-9-_]+$",
+                        "maxLength": 155,
+                        "description": "Name for the destination"
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 500,
+                        "nullable": true,
+                        "description": "Description for the destination"
+                      },
+                      "url": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Endpoint of the destination",
+                        "format": "URL"
+                      },
+                      "cli_path": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Path for the CLI destination"
+                      },
+                      "rate_limit_period": {
+                        "type": "string",
+                        "enum": ["second", "minute", "hour"],
+                        "nullable": true,
+                        "description": "Period to rate limit attempts"
+                      },
+                      "rate_limit": {
+                        "type": "integer",
+                        "oneOf": [
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"seconds\""
+                          },
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"minute\""
+                          },
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"hour\""
+                          },
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"concurrent\""
+                          }
+                        ],
+                        "nullable": true,
+                        "description": "Limit event attempts to receive per period",
+                        "x-docs-type": "integer"
+                      },
+                      "http_method": {
+                        "$ref": "#/components/schemas/DestinationHTTPMethod"
+                      },
+                      "auth_method": {
+                        "$ref": "#/components/schemas/DestinationAuthMethodConfig"
+                      },
+                      "path_forwarding_disabled": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false,
+                    "description": "Destination input object"
+                  },
+                  "source": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-z0-9-_]+$",
+                        "maxLength": 155,
+                        "description": "A unique name for the source"
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 500,
+                        "nullable": true,
+                        "description": "Description for the source"
+                      },
+                      "allowed_http_methods": {
+                        "$ref": "#/components/schemas/SourceAllowedHTTPMethod"
+                      },
+                      "custom_response": {
+                        "$ref": "#/components/schemas/SourceCustomResponse"
+                      },
+                      "verification": {
+                        "$ref": "#/components/schemas/VerificationConfig"
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false,
+                    "description": "Source input object"
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Rule"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "upsertConnection",
+        "summary": "Update or create a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "upsert",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "nullable": true,
+                    "description": "A unique name of the connection for the source"
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the connection"
+                  },
+                  "destination_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "nullable": true,
+                    "description": "ID of a destination to bind to the connection"
+                  },
+                  "source_id": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "nullable": true,
+                    "description": "ID of a source to bind to the connection"
+                  },
+                  "destination": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-z0-9-_]+$",
+                        "maxLength": 155,
+                        "description": "Name for the destination"
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 500,
+                        "nullable": true,
+                        "description": "Description for the destination"
+                      },
+                      "url": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Endpoint of the destination",
+                        "format": "URL"
+                      },
+                      "cli_path": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Path for the CLI destination"
+                      },
+                      "rate_limit_period": {
+                        "type": "string",
+                        "enum": ["second", "minute", "hour"],
+                        "nullable": true,
+                        "description": "Period to rate limit attempts"
+                      },
+                      "rate_limit": {
+                        "type": "integer",
+                        "oneOf": [
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"seconds\""
+                          },
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"minute\""
+                          },
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"hour\""
+                          },
+                          {
+                            "type": "integer",
+                            "description": "When rate limit period is set to \"concurrent\""
+                          }
+                        ],
+                        "nullable": true,
+                        "description": "Limit event attempts to receive per period",
+                        "x-docs-type": "integer"
+                      },
+                      "http_method": {
+                        "$ref": "#/components/schemas/DestinationHTTPMethod"
+                      },
+                      "auth_method": {
+                        "$ref": "#/components/schemas/DestinationAuthMethodConfig"
+                      },
+                      "path_forwarding_disabled": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false,
+                    "description": "Destination input object"
+                  },
+                  "source": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "pattern": "^[A-z0-9-_]+$",
+                        "maxLength": 155,
+                        "description": "A unique name for the source"
+                      },
+                      "description": {
+                        "type": "string",
+                        "maxLength": 500,
+                        "nullable": true,
+                        "description": "Description for the source"
+                      },
+                      "allowed_http_methods": {
+                        "$ref": "#/components/schemas/SourceAllowedHTTPMethod"
+                      },
+                      "custom_response": {
+                        "$ref": "#/components/schemas/SourceCustomResponse"
+                      },
+                      "verification": {
+                        "$ref": "#/components/schemas/VerificationConfig"
+                      }
+                    },
+                    "required": ["name"],
+                    "additionalProperties": false,
+                    "description": "Source input object"
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Rule"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/connections/count": {
+      "get": {
+        "operationId": "countConnections",
+        "summary": "Count connections",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "Count of connections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Count of connections"
+                    }
+                  },
+                  "required": ["count"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "destination_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by associated destination IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_id",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 255
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                }
+              ],
+              "description": "Filter by associated source IDs"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived",
+            "schema": {
+              "type": "boolean",
+              "description": "Include archived resources in the response"
+            }
+          },
+          {
+            "in": "query",
+            "name": "archived_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Date the connection was archived"
+            }
+          },
+          {
+            "in": "query",
+            "name": "paused_at",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": true
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "gt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "gte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "le": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "lte": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true
+                    },
+                    "any": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Date the connection was paused"
+            }
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "count"
+      }
+    },
+    "/connections/{id}": {
+      "get": {
+        "operationId": "getConnection",
+        "summary": "Get a single connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Connection ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "retrieve"
+      },
+      "put": {
+        "operationId": "updateConnection",
+        "summary": "Update a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Connection ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "update",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "pattern": "^[A-z0-9-_]+$",
+                    "maxLength": 155,
+                    "nullable": true
+                  },
+                  "description": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "nullable": true,
+                    "description": "Description for the connection"
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Rule"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteConnection",
+        "summary": "Delete a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "ID of the connection"
+                    }
+                  },
+                  "required": ["id"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "delete"
+      }
+    },
+    "/connections/{id}/archive": {
+      "put": {
+        "operationId": "archiveConnection",
+        "summary": "Archive a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Connection ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "archive"
+      }
+    },
+    "/connections/{id}/unarchive": {
+      "put": {
+        "operationId": "unarchiveConnection",
+        "summary": "Unarchive a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Connection ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "unarchive"
+      }
+    },
+    "/connections/{id}/pause": {
+      "put": {
+        "operationId": "pauseConnection",
+        "summary": "Pause a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Connection ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "pause"
+      }
+    },
+    "/connections/{id}/unpause": {
+      "put": {
+        "operationId": "unpauseConnection",
+        "summary": "Unpause a connection",
+        "description": "",
+        "tags": ["Connections"],
+        "responses": {
+          "200": {
+            "description": "A single connection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/APIErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "description": "Connection ID"
+            },
+            "required": true
+          }
+        ],
+        "x-fern-sdk-group-name": "connection",
+        "x-fern-sdk-method-name": "unpause"
       }
     }
   }


### PR DESCRIPTION
In this PR, we: 
- Revert the change to upgrade to `0.9.4` of the go generator. We do this so that the Terraform Provider will not incur any unnecessary compile breaks. 
- Restore the OpenAPI back to a formatted JSON file (so that its easy to see the diff across releases) 
- Upgrade the Fern CLI to the latest which contains bug fixes that were previously blocking releases. 